### PR TITLE
fix: change codeowners from md file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @abstractj @slaskawi @pb82 @davidffrench

--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,1 +1,0 @@
-* @abstractj @slaskawi @pb82 @davidffrench


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Codeowners wasn't working as it was a markdown file type, removing that now.

## Verification Steps
None

## Checklist:
None

## Additional Notes
None