### PR TITLE
INTLY-3462 An initial end to end test

### DIFF
--- a/test/e2e/keycloak_test.go
+++ b/test/e2e/keycloak_test.go
@@ -1,0 +1,95 @@
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	apis "github.com/keycloak/keycloak-operator/pkg/apis"
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const testKeycloakCRDName = "keycloak-test"
+const retryInterval = time.Second * 5
+const timeout = time.Second * 60
+const cleanupRetryInterval = time.Second * 1
+const cleanupTimeout = time.Second * 5
+
+type testWithDeployedOperator func(*testing.T, *framework.Framework, *framework.TestCtx) error
+
+func TestKeycloak(t *testing.T) {
+	keycloakType := &keycloakv1alpha1.Keycloak{}
+	err := framework.AddToFrameworkScheme(apis.AddToScheme, keycloakType)
+	if err != nil {
+		t.Fatalf("failed to add custom resource scheme to framework: %v", err)
+	}
+	// run subtests
+	t.Run("keycloak-group", func(t *testing.T) {
+		runTest(t, keycloakDeploymentTest)
+	})
+}
+
+func keycloakDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return fmt.Errorf("could not get namespace: %v", err)
+	}
+
+	keycloakCRD := &keycloakv1alpha1.Keycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testKeycloakCRDName,
+			Namespace: namespace,
+		},
+		Spec: keycloakv1alpha1.KeycloakSpec{
+			// FIXME: More code after the initial implementation
+		},
+	}
+	// use TestCtx's create helper to create the object and add a cleanup function for the new object
+	err = f.Client.Create(goctx.TODO(), keycloakCRD, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		return err
+	}
+	// FIXME: More code after the initial implementation
+	//err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, testKeycloakCRDName, 1, retryInterval, timeout)
+	//if err != nil {
+	//	return err
+	//}
+
+	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: testKeycloakCRDName, Namespace: namespace}, keycloakCRD)
+	if err != nil {
+		return err
+	}
+	// FIXME: More code after the initial implementation
+	return err
+}
+
+func runTest(t *testing.T, testCase testWithDeployedOperator) {
+	t.Parallel()
+	ctx := framework.NewTestCtx(t)
+	defer ctx.Cleanup()
+	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil {
+		t.Fatalf("failed to initialize cluster resources: %v", err)
+	}
+	t.Log("Initialized cluster resources")
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// get global framework variables
+	f := framework.Global
+	// wait for Keycloak Operator to be ready
+	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, testKeycloakCRDName, 1, retryInterval, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = testCase(t, f, ctx); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,11 @@
+package e2e
+
+import (
+	"testing"
+
+	f "github.com/operator-framework/operator-sdk/pkg/test"
+)
+
+func TestMain(m *testing.M) {
+	f.MainEntry(m)
+}


### PR DESCRIPTION
## JIRA ID

[INTLY-3462](https://issues.jboss.org/browse/INTLY-3462)

## Additional Information

This Pull Request contains an initial implementation of an end to end test. There will be more bits added on top of it once we have an image generation script (that comes with [INTLY-3357](https://issues.jboss.org/browse/INTLY-3357)) and initial implementation of the deployment mechanism.

## Verification Steps

I have tested this on Minishift with the following command:

```
$ operator-sdk test --verbose local ./test/e2e --debug --up-local --namespace test --debug
DEBU[0000] Debug logging is set                         
INFO[0000] Testing operator locally.                    
DEBU[0000] Running []string{"go", "test", "./test/e2e/...", "-namespacedMan", "/tmp/empty.yaml387402587", "-globalMan", "/tmp/global-manifest.yaml879177470", "-root", "/home/slaskawi/go_workspace/src/github.com/keycloak/keycloak-operator", "-singleNamespace", "-parallel=1", "-localOperator"} 
command-line-arguments
time="2019-09-13T11:56:56+02:00" level=info msg="Started local operator"
=== RUN   TestKeycloak
=== RUN   TestKeycloak/keycloak-group
=== PAUSE TestKeycloak/keycloak-group
=== CONT  TestKeycloak/keycloak-group
--- PASS: TestKeycloak (0.11s)
    --- PASS: TestKeycloak/keycloak-group (0.04s)
        keycloak_test.go:79: Initialized cluster resources
        wait_util.go:48: Operator is running locally; skip waitForDeployment
        client.go:57: resource type  with namespace/name (test/keycloak-test) created
        client.go:75: resource type  with namespace/name (test/keycloak-test) successfully deleted
PASS
time="2019-09-13T11:56:56+02:00" level=info msg="Local operator stdout: "
time="2019-09-13T11:56:56+02:00" level=info msg="Local operator stderr: {\"level\":\"info\",\"ts\":1568368616.1832688,\"logger\":\"cmd\",\"msg\":\"Go Version: go1.13\"}\n{\"level\":\"info\",\"ts\":1568368616.1833096,\"logger\":\"cmd\",\"msg\":\"Go OS/Arch: linux/amd64\"}\n{\"level\":\"info\",\"ts\":1568368616.183322,\"logger\":\"cmd\",\"msg\":\"Version of operator-sdk: v0.10.0\"}\n{\"level\":\"info\",\"ts\":1568368616.1833308,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833436,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833477,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833515,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.183355,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833584,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833618,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.183365,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833682,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.1833718,\"logger\":\"cmd\",\"msg\":\"SEBA\"}\n{\"level\":\"info\",\"ts\":1568368616.192046,\"logger\":\"leader\",\"msg\":\"Trying to become the leader.\"}\n{\"level\":\"info\",\"ts\":1568368616.19216,\"logger\":\"leader\",\"msg\":\"Skipping leader election; not running in a cluster.\"}\n{\"level\":\"info\",\"ts\":1568368616.2598248,\"logger\":\"cmd\",\"msg\":\"Registering Components.\"}\n{\"level\":\"info\",\"ts\":1568368616.2600923,\"logger\":\"kubebuilder.controller\",\"msg\":\"Starting EventSource\",\"controller\":\"keycloak-controller\",\"source\":\"kind source: /, Kind=\"}\n{\"level\":\"info\",\"ts\":1568368616.2602684,\"logger\":\"kubebuilder.controller\",\"msg\":\"Starting EventSource\",\"controller\":\"keycloak-controller\",\"source\":\"kind source: /, Kind=\"}\n{\"level\":\"info\",\"ts\":1568368616.2604253,\"logger\":\"kubebuilder.controller\",\"msg\":\"Starting EventSource\",\"controller\":\"keycloakrealm-controller\",\"source\":\"kind source: /, Kind=\"}\n{\"level\":\"info\",\"ts\":1568368616.2605412,\"logger\":\"kubebuilder.controller\",\"msg\":\"Starting EventSource\",\"controller\":\"keycloakrealm-controller\",\"source\":\"kind source: /, Kind=\"}\n{\"level\":\"info\",\"ts\":1568368616.260681,\"logger\":\"cmd\",\"msg\":\"Could not generate and serve custom resource metrics\",\"error\":\"operator run mode forced to local\"}\n"
ok  	github.com/keycloak/keycloak-operator/test/e2e	3.793s
INFO[0007] Local operator test successfully completed.  
```

Once we have an image, we can start using it (and get rid of `--up-local --namespace test` flags).

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->