### PR TITLE
[KEYCLOAK-11409] Add GolangCI to Keycloak Operator repository

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 60
+  maligned:
+    suggest-new: true
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - unparam
+    - lll
+    - gochecknoinits
+    - gochecknoglobals


### PR DESCRIPTION
## JIRA ID

[KEYCLOAK-11409](https://issues.jboss.org/browse/KEYCLOAK-11409)

## Additional Information

Fixes issues on https://github.com/keycloak/keycloak-operator/pull/6