### PR TITLE
[KEYCLOAK-11427] Add GolangCI linter to Keycloak Operator Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,3 +64,11 @@ image/build/push: image/build image/push
 test/unit:
 	@echo Running tests:
 	go test -v -race -cover ./pkg/...
+
+.PHONY: code/lint
+code/lint:
+	@echo "--> Running golangci-lint"
+	@which golangci-lint 2>/dev/null ; if [ $$? -eq 1 ]; then \
+		go get -u github.com/golangci/golangci-lint/cmd/golangci-lint; \
+	fi
+	golangci-lint run


### PR DESCRIPTION
## [KEYCLOAK-11427](https://issues.jboss.org/browse/KEYCLOAK-11427)

## What
* Enable developers to run golangci linter from the command line

## Why
* Because it helps developers to catch mistakes before submit a pull-request

## How
* Adding to the Makefile {{golangci-lint run}}

## Acceptance Criteria
* Be able to run golangci-lint using {{make code/lint}}