### PR TITLE
INTLY-3222 Use vendor by default (Go 1.12)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ code/run:
 
 .PHONY: code/compile
 code/compile:
-	@GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -o=$(COMPILE_TARGET) ./cmd/manager
+	@GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -o=$(COMPILE_TARGET) -mod=vendor ./cmd/manager
 
 .PHONY: code/gen
 code/gen:
@@ -63,7 +63,7 @@ image/build/push: image/build image/push
 .PHONY: test/unit
 test/unit:
 	@echo Running tests:
-	go test -v -race -cover ./pkg/...
+	go test -v -race -cover -mod=vendor ./pkg/...
 
 .PHONY: code/lint
 code/lint:


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
INTLY-3222

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
It seems Go 1.12 requires adding `-mod=vendor` flag.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->