### PR TITLE
[KEYCLOAK-11505] Update GolangCI lint rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,10 @@
 linters-settings:
-  govet:
-    # report about shadowed variables
-    check-shadowing: true
   golint:
     # set the confidence level of a problem before it is reported. Setting it to 0 will show every issue from golint.
     min-confidence: 0
   gocyclo:
     # a minimal complexity of function to report it
     min-complexity: 60
-  dupl:
-    # minimum token sequence size as a clone. Into other words it helps to find clones in the source code
-    threshold: 100
   goconst:
     # only report strings with the minimum given length
     min-len: 2
@@ -20,6 +14,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - dupl
     - maligned
     - unparam
     - lll

--- a/test/e2e/keycloak_test.go
+++ b/test/e2e/keycloak_test.go
@@ -3,10 +3,11 @@ package e2e
 import (
 	goctx "context"
 	"fmt"
-	apis "github.com/keycloak/keycloak-operator/pkg/apis"
-	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	"testing"
 	"time"
+
+	apis "github.com/keycloak/keycloak-operator/pkg/apis"
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"


### PR DESCRIPTION
[KEYCLOAK-11505](https://issues.jboss.org/browse/KEYCLOAK-11505)

## What
* Disable GolangCI rules for shadowing and and duplicates

## Why
* The work on the on the new Keycloak operator is based on scaffolding, which means that most of the code if fairly new and has to be refactored. Removing those rules will reduce the noise on PRs

## How
* Changing GolangCI yaml file

## Acceptance Criteria
* Have all the checks passing on GolangCI

## Additional information
* I had to run gofmt to fix the issues with e2e tests. To see what I mean, just run `make code/lint`