### PR TITLE
INTLY-3543 provide reconciler implementation and unit test

### DIFF
--- a/pkg/common/cluster_actions.go
+++ b/pkg/common/cluster_actions.go
@@ -1,0 +1,90 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ActionRunner interface {
+	RunAll(desiredState DesiredClusterState) error
+	Create(obj runtime.Object) error
+	Update(obj runtime.Object) error
+}
+
+type ClusterAction interface {
+	Run(runner ActionRunner) (string, error)
+}
+
+type ClusterActionRunner struct {
+	client client.Client
+	logger logr.Logger
+}
+
+func NewClusterActionRunner(client client.Client, logger logr.Logger) ActionRunner {
+	return &ClusterActionRunner{
+		client: client,
+		logger: logger,
+	}
+}
+
+func (i *ClusterActionRunner) RunAll(desiredState DesiredClusterState) error {
+	for index, action := range desiredState {
+		msg, err := action.Run(i)
+		if err != nil {
+			i.logger.Info(fmt.Sprintf("(%5d) %10s %s", index, "FAILED", msg))
+			return err
+		}
+		i.logger.Info(fmt.Sprintf("(%5d) %10s %s", index, "SUCCESS", msg))
+	}
+
+	return nil
+}
+
+func (i *ClusterActionRunner) Create(obj runtime.Object) error {
+	return i.client.Create(context.TODO(), obj)
+}
+
+func (i *ClusterActionRunner) Update(obj runtime.Object) error {
+	return i.client.Update(context.TODO(), obj)
+}
+
+// An action to create generic kubernetes resources
+// (resources that don't require special treatment)
+type GenericCreateAction struct {
+	Ref runtime.Object
+	Msg string
+}
+
+// An action to update generic kubernetes resources
+// (resources that don't require special treatment)
+type GenericUpdateAction struct {
+	Ref runtime.Object
+	Msg string
+}
+
+// Services need to have a valid ClusterIP and ResourceVersion in
+// order to be updated
+type ServiceUpdateAction struct {
+	Ref             *v1.Service
+	Msg             string
+	ClusterIP       string
+	ResourceVersion string
+}
+
+func (i GenericCreateAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.Create(i.Ref)
+}
+
+func (i GenericUpdateAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.Update(i.Ref)
+}
+
+func (i ServiceUpdateAction) Run(runner ActionRunner) (string, error) {
+	i.Ref.ResourceVersion = i.ResourceVersion
+	i.Ref.Spec.ClusterIP = i.ClusterIP
+	return i.Msg, runner.Update(i.Ref)
+}

--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -30,12 +30,13 @@ func (i *ClusterState) Read(cr *kc.Keycloak) {
 
 // Keycloak service
 func (i *ClusterState) readKeycloakServiceCurrentState(cr *kc.Keycloak) {
-	keycloakService := keycloak.KeycloakService(cr)
+	keycloakService := keycloak.Service(cr)
 
 	selector := client.ObjectKey{
 		Name:      keycloakService.Name,
 		Namespace: keycloakService.Namespace,
 	}
+
 	err := i.client.Get(context.TODO(), selector, keycloakService)
 	if err != nil {
 		i.KeycloakService = nil

--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"context"
+	kc "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/keycloak/keycloak-operator/pkg/model/keycloak"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// The desired cluster state is defined by a list of actions that have to be run to
+// get from the current state to the desired state
+type DesiredClusterState []ClusterAction
+
+type ClusterState struct {
+	KeycloakService *v1.Service
+	client          client.Client
+}
+
+func NewClusterState(client client.Client) *ClusterState {
+	return &ClusterState{
+		KeycloakService: nil,
+		client:          client,
+	}
+}
+
+func (i *ClusterState) Read(cr *kc.Keycloak) {
+	i.readKeycloakServiceCurrentState(cr)
+}
+
+// Keycloak service
+func (i *ClusterState) readKeycloakServiceCurrentState(cr *kc.Keycloak) {
+	keycloakService := keycloak.KeycloakService(cr)
+
+	selector := client.ObjectKey{
+		Name:      keycloakService.Name,
+		Namespace: keycloakService.Namespace,
+	}
+	err := i.client.Get(context.TODO(), selector, keycloakService)
+	if err != nil {
+		i.KeycloakService = nil
+	} else {
+		i.KeycloakService = keycloakService.DeepCopy()
+	}
+}

--- a/pkg/controller/keycloak/keycloak_controller.go
+++ b/pkg/controller/keycloak/keycloak_controller.go
@@ -115,8 +115,8 @@ func (r *ReconcileKeycloak) Reconcile(request reconcile.Request) (reconcile.Resu
 	currentState.Read(instance)
 
 	// Reconcile with desired state
-	keycloakReconciler := NewKeycloakReconciler(currentState, r.runner)
-	err = keycloakReconciler.Reconcile(instance)
+	reconciler := NewKeycloakReconciler(currentState, r.runner)
+	err = reconciler.Reconcile(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -1,26 +1,24 @@
 package keycloak
 
 import (
-	"github.com/go-logr/logr"
 	kc "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	"github.com/keycloak/keycloak-operator/pkg/common"
 	"github.com/keycloak/keycloak-operator/pkg/model/keycloak"
 )
 
-type KeycloakReconciler struct {
-	logger       logr.Logger
+type Reconciler struct {
 	clusterState *common.ClusterState
 	runner       common.ActionRunner
 }
 
-func NewKeycloakReconciler(state *common.ClusterState, runner common.ActionRunner) *KeycloakReconciler {
-	return &KeycloakReconciler{
+func NewKeycloakReconciler(state *common.ClusterState, runner common.ActionRunner) *Reconciler {
+	return &Reconciler{
 		clusterState: state,
 		runner:       runner,
 	}
 }
 
-func (i *KeycloakReconciler) Reconcile(cr *kc.Keycloak) error {
+func (i *Reconciler) Reconcile(cr *kc.Keycloak) error {
 	// Create the desired cluster state as a list of modifications to the
 	// current state
 	desiredState := i.buildDesiredState(cr)
@@ -29,26 +27,26 @@ func (i *KeycloakReconciler) Reconcile(cr *kc.Keycloak) error {
 	return i.runner.RunAll(desiredState)
 }
 
-func (i *KeycloakReconciler) buildDesiredState(cr *kc.Keycloak) common.DesiredClusterState {
+func (i *Reconciler) buildDesiredState(cr *kc.Keycloak) common.DesiredClusterState {
 	desired := common.DesiredClusterState{}
 	desired = append(desired, i.getKeycloakServiceDesiredState(cr))
 	return desired
 }
 
-func (i *KeycloakReconciler) getKeycloakServiceDesiredState(cr *kc.Keycloak) common.ClusterAction {
-	service := keycloak.KeycloakService(cr)
+func (i *Reconciler) getKeycloakServiceDesiredState(cr *kc.Keycloak) common.ClusterAction {
+	service := keycloak.Service(cr)
 
 	if i.clusterState.KeycloakService == nil {
 		return common.GenericCreateAction{
 			Ref: service,
 			Msg: "create keycloak service",
 		}
-	} else {
-		return common.ServiceUpdateAction{
-			Ref:             service,
-			Msg:             "update keycloak service",
-			ClusterIP:       i.clusterState.KeycloakService.Spec.ClusterIP,
-			ResourceVersion: i.clusterState.KeycloakService.ResourceVersion,
-		}
+	}
+
+	return common.ServiceUpdateAction{
+		Ref:             service,
+		Msg:             "update keycloak service",
+		ClusterIP:       i.clusterState.KeycloakService.Spec.ClusterIP,
+		ResourceVersion: i.clusterState.KeycloakService.ResourceVersion,
 	}
 }

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -1,0 +1,54 @@
+package keycloak
+
+import (
+	"github.com/go-logr/logr"
+	kc "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/keycloak/keycloak-operator/pkg/common"
+	"github.com/keycloak/keycloak-operator/pkg/model/keycloak"
+)
+
+type KeycloakReconciler struct {
+	logger       logr.Logger
+	clusterState *common.ClusterState
+	runner       common.ActionRunner
+}
+
+func NewKeycloakReconciler(state *common.ClusterState, runner common.ActionRunner) *KeycloakReconciler {
+	return &KeycloakReconciler{
+		clusterState: state,
+		runner:       runner,
+	}
+}
+
+func (i *KeycloakReconciler) Reconcile(cr *kc.Keycloak) error {
+	// Create the desired cluster state as a list of modifications to the
+	// current state
+	desiredState := i.buildDesiredState(cr)
+
+	// Run all the modifications (actions)
+	return i.runner.RunAll(desiredState)
+}
+
+func (i *KeycloakReconciler) buildDesiredState(cr *kc.Keycloak) common.DesiredClusterState {
+	desired := common.DesiredClusterState{}
+	desired = append(desired, i.getKeycloakServiceDesiredState(cr))
+	return desired
+}
+
+func (i *KeycloakReconciler) getKeycloakServiceDesiredState(cr *kc.Keycloak) common.ClusterAction {
+	service := keycloak.KeycloakService(cr)
+
+	if i.clusterState.KeycloakService == nil {
+		return common.GenericCreateAction{
+			Ref: service,
+			Msg: "create keycloak service",
+		}
+	} else {
+		return common.ServiceUpdateAction{
+			Ref:             service,
+			Msg:             "update keycloak service",
+			ClusterIP:       i.clusterState.KeycloakService.Spec.ClusterIP,
+			ResourceVersion: i.clusterState.KeycloakService.ResourceVersion,
+		}
+	}
+}

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -16,7 +16,10 @@ func TestKeycloakReconciler_Reconcile(t *testing.T) {
 	}
 
 	reconciler := NewKeycloakReconciler(currentState, actionRunner)
-	reconciler.Reconcile(&mockCr)
+	err := reconciler.Reconcile(&mockCr)
+	if err != nil {
+		t.Error(err)
+	}
 
 	runner := reconciler.runner.(*test.MockActionRunner)
 	if runner.ResourcesCreated != 1 {

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -1,0 +1,29 @@
+package keycloak
+
+import (
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/keycloak/keycloak-operator/pkg/common"
+	"github.com/keycloak/keycloak-operator/pkg/test"
+	"testing"
+)
+
+var actionRunner = test.NewMockActionRunner()
+var mockCr = v1alpha1.Keycloak{}
+
+func TestKeycloakReconciler_Reconcile(t *testing.T) {
+	currentState := &common.ClusterState{
+		KeycloakService: nil,
+	}
+
+	reconciler := NewKeycloakReconciler(currentState, actionRunner)
+	reconciler.Reconcile(&mockCr)
+
+	runner := reconciler.runner.(*test.MockActionRunner)
+	if runner.ResourcesCreated != 1 {
+		t.Error("invalid number of resources created")
+	}
+
+	if runner.ResourcesUpdated != 0 {
+		t.Error("invalid number of resources updated")
+	}
+}

--- a/pkg/model/keycloak/constants.go
+++ b/pkg/model/keycloak/constants.go
@@ -1,0 +1,6 @@
+package keycloak
+
+// Constants for a community Keycloak installation
+const (
+	ApplicationName = "keycloak"
+)

--- a/pkg/model/keycloak/keycloak_service.go
+++ b/pkg/model/keycloak/keycloak_service.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func KeycloakService(cr *v1alpha1.Keycloak) *v1.Service {
+func Service(cr *v1alpha1.Keycloak) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      ApplicationName,

--- a/pkg/model/keycloak/keycloak_service.go
+++ b/pkg/model/keycloak/keycloak_service.go
@@ -1,0 +1,28 @@
+package keycloak
+
+import (
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func KeycloakService(cr *v1alpha1.Keycloak) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      ApplicationName,
+			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				"application": ApplicationName,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Port:       8443,
+					TargetPort: intstr.Parse("8443"),
+				},
+			},
+		},
+	}
+}

--- a/pkg/model/rhsso/constants.go
+++ b/pkg/model/rhsso/constants.go
@@ -1,0 +1,4 @@
+package rhsso
+
+// Constants for a rhsso installation
+const ()

--- a/pkg/test/mock_cluster_actions.go
+++ b/pkg/test/mock_cluster_actions.go
@@ -1,0 +1,41 @@
+package test
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/keycloak/keycloak-operator/pkg/common"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type MockActionRunner struct {
+	logger           logr.Logger
+	ResourcesCreated int
+	ResourcesUpdated int
+}
+
+func NewMockActionRunner() common.ActionRunner {
+	return &MockActionRunner{
+		ResourcesCreated: 0,
+		ResourcesUpdated: 0,
+	}
+}
+
+func (i *MockActionRunner) Create(obj runtime.Object) error {
+	i.ResourcesCreated = i.ResourcesCreated + 1
+	return nil
+}
+
+func (i *MockActionRunner) Update(obj runtime.Object) error {
+	i.ResourcesUpdated = i.ResourcesUpdated + 1
+	return nil
+}
+
+func (i *MockActionRunner) RunAll(desiredState common.DesiredClusterState) error {
+	for _, action := range desiredState {
+		_, err := action.Run(i)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/test/mock_cluster_actions.go
+++ b/pkg/test/mock_cluster_actions.go
@@ -1,13 +1,11 @@
 package test
 
 import (
-	"github.com/go-logr/logr"
 	"github.com/keycloak/keycloak-operator/pkg/common"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type MockActionRunner struct {
-	logger           logr.Logger
 	ResourcesCreated int
 	ResourcesUpdated int
 }
@@ -20,12 +18,12 @@ func NewMockActionRunner() common.ActionRunner {
 }
 
 func (i *MockActionRunner) Create(obj runtime.Object) error {
-	i.ResourcesCreated = i.ResourcesCreated + 1
+	i.ResourcesCreated++
 	return nil
 }
 
 func (i *MockActionRunner) Update(obj runtime.Object) error {
-	i.ResourcesUpdated = i.ResourcesUpdated + 1
+	i.ResourcesUpdated++
 	return nil
 }
 


### PR DESCRIPTION
## JIRA ID

INTLY-3543

Provides an implementation for the reconciler based on the discussed approach:

In every reconciliation we determine the current cluster state.
The current cluster state combined with the Keycloak CR is used to generate the desired cluster state.
The desired cluster state is a list of actions that need to be run in order to get the cluster from the current state into the desired state.

Those actions are then passed to an `ActionRunner` which will actually perform them against the cluster.

There are two implementations of `ActionRunner`: `ClusterActionRunner` for performing real actions and `MockActionRunner` for Unit tests (which only count the number of updates, creates, etc.)

A sample unit test is provided.