### PR TITLE
feat: Adding context to operator

### DIFF
--- a/pkg/common/cluster_actions.go
+++ b/pkg/common/cluster_actions.go
@@ -22,12 +22,14 @@ type ClusterAction interface {
 }
 
 type ClusterActionRunner struct {
-	client client.Client
+	client  client.Client
+	context context.Context
 }
 
-func NewClusterActionRunner(client client.Client) ActionRunner {
+func NewClusterActionRunner(context context.Context, client client.Client) ActionRunner {
 	return &ClusterActionRunner{
-		client: client,
+		client:  client,
+		context: context,
 	}
 }
 
@@ -45,11 +47,11 @@ func (i *ClusterActionRunner) RunAll(desiredState DesiredClusterState) error {
 }
 
 func (i *ClusterActionRunner) Create(obj runtime.Object) error {
-	return i.client.Create(context.TODO(), obj)
+	return i.client.Create(i.context, obj)
 }
 
 func (i *ClusterActionRunner) Update(obj runtime.Object) error {
-	return i.client.Update(context.TODO(), obj)
+	return i.client.Update(i.context, obj)
 }
 
 // An action to create generic kubernetes resources

--- a/pkg/common/cluster_actions_test.go
+++ b/pkg/common/cluster_actions_test.go
@@ -59,7 +59,7 @@ var TestServiceSelector = client.ObjectKey{
 func TestClusterActionRunner_Test_Create_Action(t *testing.T) {
 	// given
 	mockClient := fake.NewFakeClient()
-	actionRunner := NewClusterActionRunner(mockClient)
+	actionRunner := NewClusterActionRunner(context.TODO(), mockClient)
 
 	testedAction := GenericCreateAction{
 		Ref: TestService.DeepCopy(),
@@ -78,7 +78,7 @@ func TestClusterActionRunner_Test_Create_Action(t *testing.T) {
 func TestClusterActionRunner_Test_Update_Action(t *testing.T) {
 	// given
 	mockClient := fake.NewFakeClient(TestServiceWithModifiedPort.DeepCopy())
-	actionRunner := NewClusterActionRunner(mockClient)
+	actionRunner := NewClusterActionRunner(context.TODO(), mockClient)
 
 	testedAction := GenericUpdateAction{
 		Ref: TestService.DeepCopy(),

--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -24,19 +24,19 @@ func NewClusterState() *ClusterState {
 	}
 }
 
-func (i *ClusterState) Read(cr *kc.Keycloak, controllerClient client.Client) error {
-	return i.readKeycloakServiceCurrentState(cr, controllerClient)
+func (i *ClusterState) Read(context context.Context, cr *kc.Keycloak, controllerClient client.Client) error {
+	return i.readKeycloakServiceCurrentState(context, cr, controllerClient)
 }
 
 // Keycloak service
-func (i *ClusterState) readKeycloakServiceCurrentState(cr *kc.Keycloak, controllerClient client.Client) error {
+func (i *ClusterState) readKeycloakServiceCurrentState(context context.Context, cr *kc.Keycloak, controllerClient client.Client) error {
 	keycloakService := keycloak.Service(cr)
 
 	selector := client.ObjectKey{
 		Name:      keycloakService.Name,
 		Namespace: keycloakService.Namespace,
 	}
-	err := controllerClient.Get(context.TODO(), selector, keycloakService)
+	err := controllerClient.Get(context, selector, keycloakService)
 
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Removing `context.TODO()` and adding context to the operator based on [this issue](https://github.com/keycloak/keycloak-operator/issues/23) opened by @philbrookes

## Verification Steps
All tests are passing

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

