### PR TITLE
[KEYCLOAK-11498] Add Coveralls to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
-
 matrix:
   include:
   - go: 1.12.x
     env: GO111MODULE=on
-    
 script:
 - make test/unit
+- make code/goveralls

--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,18 @@ code/lint:
 setup/travis:
 	@echo Installing Operator SDK
 	@curl -Lo operator-sdk ${OPERATOR_SDK_DOWNLOAD_URL} && chmod +x operator-sdk && sudo mv operator-sdk /usr/local/bin/
+
+.PHONY: code/coverage
+code/coverage:
+	@echo "--> Running go coverage"
+	@which cover 2>/dev/null ; if [ $$? -eq 1 ]; then \
+		go get golang.org/x/tools/cmd/cover; \
+	fi
+	@go test -coverprofile cover.out -mod=vendor ./pkg/...
+	@go tool cover -html=cover.out -o cover.html
+
+.PHONY: code/goveralls
+code/goveralls: code/coverage
+	go get -u github.com/mattn/goveralls
+	@echo "--> Running goveralls"
+	@goveralls -coverprofile=cover.out -service=travis-ci


### PR DESCRIPTION
## [KEYCLOAK-11498](https://issues.jboss.org/browse/KEYCLOAK-11498)

## Additional Information
* Included tasks into the Makefile to centralize everything in a single place
* `make/coverage` may overlap with `make/unit` so we might want to consider to merge then in a single command

## Verification Steps
* See: https://coveralls.io/github/abstractj/keycloak-operator