### PR TITLE
Minor fix for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Other contants
 NAMESPACE=keycloak
+PROJECT=keycloak-operator
 PKG=github.com/keycloak/keycloak-operator
 OPERATOR_SDK_VERSION=v0.10.0
 OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu


### PR DESCRIPTION
The command `make code/compile` will fail if project variable is not provided. In order to fix this, we just need to add the project name on top of the Makefile

I didn't fine any Jira because is a really minor fix.