### PR TITLE
Minor fix for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Other contants
 NAMESPACE=keycloak
+PROJECT=keycloak-operator
 PKG=github.com/keycloak/keycloak-operator
 OPERATOR_SDK_VERSION=v0.10.0
 OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/keycloak/keycloak-operator
 
 require (
-	github.com/NYTimes/gziphandler v1.0.1 // indirect
 	github.com/go-openapi/spec v0.19.0
 	github.com/operator-framework/operator-sdk v0.10.1-0.20190911145116-334c667503d0
 	github.com/spf13/pflag v1.0.3


### PR DESCRIPTION
The command `make code/compile` will fail if project variable is not provided. In order to fix this, we just need to add the project name on top of the Makefile

I didn't create any Jiras because it's just a minor fix