### PR TITLE
feat: Reconcile keycloak admin secret

### DIFF
--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -21,6 +21,8 @@ func NewKeycloakReconciler() *KeycloakReconciler {
 
 func (i *KeycloakReconciler) Reconcile(clusterState *common.ClusterState, cr *kc.Keycloak) (common.DesiredClusterState, error) {
 	desired := common.DesiredClusterState{}
+
+	desired = desired.AddAction(i.GetKeycloakAdminSecretDesiredState(clusterState, cr))
 	desired = desired.AddAction(i.GetKeycloakPrometheusRuleDesiredState(clusterState, cr))
 	desired = desired.AddAction(i.GetKeycloakServiceMonitorDesiredState(clusterState, cr))
 	desired = desired.AddAction(i.GetKeycloakGrafanaDashboardDesiredState(clusterState, cr))
@@ -32,6 +34,21 @@ func (i *KeycloakReconciler) Reconcile(clusterState *common.ClusterState, cr *kc
 	desired = desired.AddAction(i.getKeycloakDiscoveryServiceDesiredState(clusterState, cr))
 	desired = desired.AddAction(i.getKeycloakDeploymentDesiredState(clusterState, cr))
 	return desired, nil
+}
+
+func (i *KeycloakReconciler) GetKeycloakAdminSecretDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
+	keycloakAdminSecret := model.KeycloakAdminSecret(cr)
+
+	if clusterState.PostgresqlPersistentVolumeClaim == nil {
+		return common.GenericCreateAction{
+			Ref: keycloakAdminSecret,
+			Msg: "Create Keycloak admin secret",
+		}
+	}
+	return common.GenericUpdateAction{
+		Ref: keycloakAdminSecret,
+		Msg: "Update Keycloak admin secret",
+	}
 }
 
 func (i *KeycloakReconciler) getPostgresqlPersistentVolumeClaimDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -50,16 +50,18 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[7])
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[8])
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[9])
-	assert.IsType(t, model.PrometheusRule(cr), desiredState[0].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.ServiceMonitor(cr), desiredState[1].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[2].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.DatabaseSecret(cr), desiredState[3].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[4].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[5].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlService(cr), desiredState[6].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.KeycloakService(cr), desiredState[7].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[8].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[9].(common.GenericCreateAction).Ref)
+	assert.IsType(t, common.GenericCreateAction{}, desiredState[10])
+	assert.IsType(t, model.KeycloakAdminSecret(cr), desiredState[0].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PrometheusRule(cr), desiredState[1].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.ServiceMonitor(cr), desiredState[2].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[3].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlService(cr), desiredState[7].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[10].(common.GenericCreateAction).Ref)
 }
 
 func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
@@ -76,6 +78,7 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 		KeycloakService:                 model.KeycloakService(cr),
 		KeycloakDiscoveryService:        model.KeycloakDiscoveryService(cr),
 		KeycloakDeployment:              model.KeycloakDeployment(cr),
+		KeycloakAdminSecret:             model.KeycloakAdminSecret(cr),
 	}
 
 	//Set monitoring resources exist to true
@@ -111,16 +114,18 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[7])
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[8])
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[9])
-	assert.IsType(t, model.PrometheusRule(cr), desiredState[0].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.ServiceMonitor(cr), desiredState[1].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[2].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.DatabaseSecret(cr), desiredState[3].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[4].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[5].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.PostgresqlService(cr), desiredState[6].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.KeycloakService(cr), desiredState[7].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[8].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[9].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, common.GenericUpdateAction{}, desiredState[10])
+	assert.IsType(t, model.KeycloakAdminSecret(cr), desiredState[0].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PrometheusRule(cr), desiredState[1].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.ServiceMonitor(cr), desiredState[2].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[3].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PostgresqlService(cr), desiredState[7].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[10].(common.GenericUpdateAction).Ref)
 }
 
 func TestKeycloakReconciler_Test_No_Action_When_Monitoring_Resources_Dont_Exist(t *testing.T) {

--- a/pkg/model/keycloak_admin_secret.go
+++ b/pkg/model/keycloak_admin_secret.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func KeycloakAdminSecret(cr *v1alpha1.Keycloak) *v1.Secret {
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      "credential-" + cr.Name,
+			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				"application":   ApplicationName,
+				ApplicationName: cr.Name,
+			},
+		},
+		Data: map[string][]byte{
+			"SSO_ADMIN_USERNAME": []byte("admin"),
+			"SSO_ADMIN_PASSWORD": []byte(randStringRunes(10)),
+		},
+		Type: "Opaque",
+	}
+}
+
+func KeycloakAdminSecretSelector(cr *v1alpha1.Keycloak) client.ObjectKey {
+	return client.ObjectKey{
+		Name:      "credential-" + cr.Name,
+		Namespace: cr.Namespace,
+	}
+}

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -1,6 +1,8 @@
 package model
 
-import "math/rand"
+import (
+	"math/rand"
+)
 
 // Copy pasted from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")


### PR DESCRIPTION
## JIRA ID
https://issues.jboss.org/browse/INTLY-3608

## Additional Information
Adding keycloak admin username, password. Will also hold the url once the Ingress is in place.

## Verification Steps
1. Run operator locally and see secret is created and reconciled.

## Checklist:
- [ ] Verified by team member
- [x] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->