### PR TITLE
fix: Refactoring autodetect and statemanagement

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/keycloak/keycloak-operator/pkg/common"
 	routev1 "github.com/openshift/api/route/v1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -130,8 +131,16 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Create and start a new auto detect process for this operator
+	autodetect, err := common.NewAutoDetect(mgr)
+	if err != nil {
+		log.Error(err, "failed to start the background process to auto-detect the operator capabilities")
+	} else {
+		autodetect.Start()
+	}
+
 	// Setup all Controllers
-	if err := controller.AddToManager(mgr); err != nil {
+	if err := controller.AddToManager(mgr, autodetect.SubscriptionChannel); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/pkg/common/auto_detect.go
+++ b/pkg/common/auto_detect.go
@@ -68,6 +68,10 @@ func (b *Background) autoDetectCapabilities() {
 func (b *Background) detectRoute() {
 	resourceExists, _ := k8sutil.ResourceExists(b.dc, routev1.SchemeGroupVersion.String(), RouteKind)
 	if resourceExists {
+		// Set state that the Route kind exists. Used to determine when a route or an Ingress should be created
+		stateManager := GetStateManager()
+		stateManager.SetState(RouteKind, true)
+
 		b.SubscriptionChannel <- routev1.SchemeGroupVersion.WithKind(RouteKind)
 	}
 }

--- a/pkg/common/auto_detect.go
+++ b/pkg/common/auto_detect.go
@@ -1,26 +1,18 @@
 package common
 
 import (
-	"fmt"
-	"time"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
-	"k8s.io/apimachinery/pkg/runtime"
+	"time"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	i8ly "github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1"
-	kc "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
-
-var logger = logf.Log.WithName("autodetect")
 
 // Route kind is not provided by the openshift api
 const (
@@ -29,20 +21,23 @@ const (
 
 // Background represents a procedure that runs in the background, periodically auto-detecting features
 type Background struct {
-	client     client.Client
-	dc         discovery.DiscoveryInterface
-	controller controller.Controller
-	ticker     *time.Ticker
+	client              client.Client
+	dc                  discovery.DiscoveryInterface
+	ticker              *time.Ticker
+	SubscriptionChannel chan schema.GroupVersionKind
 }
 
 // New creates a new auto-detect runner
-func NewAutoDetect(mgr manager.Manager, c controller.Controller) (*Background, error) {
+func NewAutoDetect(mgr manager.Manager) (*Background, error) {
 	dc, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return nil, err
 	}
 
-	return &Background{dc: dc, client: mgr.GetClient(), controller: c}, nil
+	// Create a new channel that GVK type will be sent down
+	subChan := make(chan schema.GroupVersionKind, 1)
+
+	return &Background{dc: dc, client: mgr.GetClient(), SubscriptionChannel: subChan}, nil
 }
 
 // Start initializes the auto-detection process that runs in the background
@@ -50,20 +45,11 @@ func (b *Background) Start() {
 	// periodically attempts to auto detect all the capabilities for this operator
 	b.ticker = time.NewTicker(5 * time.Second)
 
-	done := make(chan bool)
 	go func() {
 		b.autoDetectCapabilities()
-		done <- true
-	}()
 
-	go func() {
-		for {
-			select {
-			case <-done:
-				logger.Info("finished the first auto-detection")
-			case <-b.ticker.C:
-				b.autoDetectCapabilities()
-			}
+		for range b.ticker.C {
+			b.autoDetectCapabilities()
 		}
 	}()
 }
@@ -71,6 +57,7 @@ func (b *Background) Start() {
 // Stop causes the background process to stop auto detecting capabilities
 func (b *Background) Stop() {
 	b.ticker.Stop()
+	close(b.SubscriptionChannel)
 }
 
 func (b *Background) autoDetectCapabilities() {
@@ -80,48 +67,27 @@ func (b *Background) autoDetectCapabilities() {
 
 func (b *Background) detectRoute() {
 	resourceExists, _ := k8sutil.ResourceExists(b.dc, routev1.SchemeGroupVersion.String(), RouteKind)
-	b.tryWatch(resourceExists, RouteKind, &routev1.Route{})
+	if resourceExists {
+		b.SubscriptionChannel <- routev1.SchemeGroupVersion.WithKind(RouteKind)
+	}
 }
 
 func (b *Background) detectMonitoringResources() {
 	// detect the PrometheusRule resource type exist on the cluster
 	resourceExists, _ := k8sutil.ResourceExists(b.dc, monitoringv1.SchemeGroupVersion.String(), monitoringv1.PrometheusRuleKind)
-	b.tryWatch(resourceExists, monitoringv1.PrometheusRuleKind, &monitoringv1.PrometheusRule{})
+	if resourceExists {
+		b.SubscriptionChannel <- monitoringv1.SchemeGroupVersion.WithKind(monitoringv1.PrometheusRuleKind)
+	}
 
 	// detect the ServiceMonitor resource type exist on the cluster
 	resourceExists, _ = k8sutil.ResourceExists(b.dc, monitoringv1.SchemeGroupVersion.String(), monitoringv1.ServiceMonitorsKind)
-	b.tryWatch(resourceExists, monitoringv1.ServiceMonitorsKind, &monitoringv1.ServiceMonitor{})
+	if resourceExists {
+		b.SubscriptionChannel <- monitoringv1.SchemeGroupVersion.WithKind(monitoringv1.ServiceMonitorsKind)
+	}
 
 	// detect the GrafanaDashboard resource type resourceExists on the cluster
 	resourceExists, _ = k8sutil.ResourceExists(b.dc, i8ly.SchemeGroupVersion.String(), i8ly.GrafanaDashboardKind)
-	b.tryWatch(resourceExists, i8ly.GrafanaDashboardKind, &i8ly.GrafanaDashboard{})
-}
-
-func (b *Background) tryWatch(resourceExists bool, kind string, o runtime.Object) {
-	if !resourceExists {
-		return
-	}
-
-	stateManager := GetStateManager()
-	watchExists, keyExists := stateManager.GetState(kind).(bool)
-
-	// If no key esists yet, but the resource exists, set up a watch
-	// If not no key exists, but no watch exists yet, set up a watch
-	if !keyExists || !watchExists {
-		// Try to set up the actual watch
-		err := b.controller.Watch(&source.Kind{Type: o}, &handler.EnqueueRequestForOwner{
-			IsController: true,
-			OwnerType:    &kc.Keycloak{},
-		})
-
-		// Retry on error
-		if err != nil {
-			logger.Error(err, "error creating watch")
-			stateManager.SetState(kind, false)
-			return
-		}
-
-		stateManager.SetState(kind, true)
-		logger.Info(fmt.Sprintf("'%s' type exists, watch created", kind))
+	if resourceExists {
+		b.SubscriptionChannel <- i8ly.SchemeGroupVersion.WithKind(i8ly.GrafanaDashboardKind)
 	}
 }

--- a/pkg/common/state_manager.go
+++ b/pkg/common/state_manager.go
@@ -3,6 +3,7 @@ package common
 import "sync"
 
 type stateManager struct {
+	*sync.Mutex
 	state map[string]interface{}
 }
 
@@ -11,14 +12,20 @@ var once sync.Once
 
 func GetStateManager() *stateManager {
 	once.Do(func() {
-		singleton = &stateManager{}
+		singleton = &stateManager{Mutex: &sync.Mutex{}}
 		singleton.state = make(map[string]interface{})
 	})
 	return singleton
 }
+
 func (sm *stateManager) GetState(key string) interface{} {
+	sm.Lock()
+	defer sm.Unlock()
 	return sm.state[key]
 }
+
 func (sm *stateManager) SetState(key string, value interface{}) {
+	sm.Lock()
+	defer sm.Unlock()
 	sm.state[key] = value
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,17 @@
 package controller
 
 import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager) error
+var AddToManagerFuncs []func(manager.Manager, chan schema.GroupVersionKind) error
 
 // AddToManager adds all Controllers to the Manager
-func AddToManager(m manager.Manager) error {
+func AddToManager(m manager.Manager, autodetect chan schema.GroupVersionKind) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m); err != nil {
+		if err := f(m, autodetect); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/keycloak/keycloak_controller.go
+++ b/pkg/controller/keycloak/keycloak_controller.go
@@ -184,5 +184,5 @@ func watchSecondaryResource(c controller.Controller, gvk schema.GroupVersionKind
 }
 
 func getStateFieldName(kind string) string {
-	return ControllerName + "-" + kind
+	return ControllerName + "-watch-" + kind
 }

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -169,9 +169,9 @@ func (i *KeycloakReconciler) GetKeycloakPrometheusRuleDesiredState(clusterState 
 
 func (i *KeycloakReconciler) GetKeycloakServiceMonitorDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	stateManager := common.GetStateManager()
-	resourceExists, keyExists := stateManager.GetState(getStateFieldName(monitoringv1.ServiceMonitorsKind)).(bool)
+	resourceWatchExists, keyExists := stateManager.GetState(getStateFieldName(monitoringv1.ServiceMonitorsKind)).(bool)
 	// Only add or update the monitoring resources if the resource type exists on the cluster. These booleans are set in the common/autodetect logic
-	if !keyExists || !resourceExists {
+	if !keyExists || !resourceWatchExists {
 		return nil
 	}
 
@@ -193,9 +193,9 @@ func (i *KeycloakReconciler) GetKeycloakServiceMonitorDesiredState(clusterState 
 
 func (i *KeycloakReconciler) GetKeycloakGrafanaDashboardDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	stateManager := common.GetStateManager()
-	resourceExists, keyExists := stateManager.GetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind)).(bool)
+	resourceWatchExists, keyExists := stateManager.GetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind)).(bool)
 	// Only add or update the monitoring resources if the resource type exists on the cluster. These booleans are set in the common/autodetect logic
-	if !keyExists || !resourceExists {
+	if !keyExists || !resourceWatchExists {
 		return nil
 	}
 

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -145,9 +145,9 @@ func (i *KeycloakReconciler) getKeycloakDiscoveryServiceDesiredState(clusterStat
 
 func (i *KeycloakReconciler) GetKeycloakPrometheusRuleDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	stateManager := common.GetStateManager()
-	resourceExists, keyExists := stateManager.GetState(monitoringv1.PrometheusRuleKind).(bool)
+	resourceWatchExists, keyExists := stateManager.GetState(getStateFieldName(monitoringv1.PrometheusRuleKind)).(bool)
 	// Only add or update the monitoring resources if the resource type exists on the cluster. These booleans are set in the common/autodetect logic
-	if !keyExists || !resourceExists {
+	if !keyExists || !resourceWatchExists {
 		return nil
 	}
 
@@ -169,7 +169,7 @@ func (i *KeycloakReconciler) GetKeycloakPrometheusRuleDesiredState(clusterState 
 
 func (i *KeycloakReconciler) GetKeycloakServiceMonitorDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	stateManager := common.GetStateManager()
-	resourceExists, keyExists := stateManager.GetState(monitoringv1.ServiceMonitorsKind).(bool)
+	resourceExists, keyExists := stateManager.GetState(getStateFieldName(monitoringv1.ServiceMonitorsKind)).(bool)
 	// Only add or update the monitoring resources if the resource type exists on the cluster. These booleans are set in the common/autodetect logic
 	if !keyExists || !resourceExists {
 		return nil
@@ -193,7 +193,7 @@ func (i *KeycloakReconciler) GetKeycloakServiceMonitorDesiredState(clusterState 
 
 func (i *KeycloakReconciler) GetKeycloakGrafanaDashboardDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	stateManager := common.GetStateManager()
-	resourceExists, keyExists := stateManager.GetState(integreatlyv1alpha1.GrafanaDashboardKind).(bool)
+	resourceExists, keyExists := stateManager.GetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind)).(bool)
 	// Only add or update the monitoring resources if the resource type exists on the cluster. These booleans are set in the common/autodetect logic
 	if !keyExists || !resourceExists {
 		return nil

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -19,9 +19,9 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 
 	//Set monitoring resources exist to true
 	stateManager := common.GetStateManager()
-	stateManager.SetState(monitoringv1.PrometheusRuleKind, true)
-	stateManager.SetState(monitoringv1.ServiceMonitorsKind, true)
-	stateManager.SetState(integreatlyv1alpha1.GrafanaDashboardKind, true)
+	stateManager.SetState(getStateFieldName(monitoringv1.PrometheusRuleKind), true)
+	stateManager.SetState(getStateFieldName(monitoringv1.ServiceMonitorsKind), true)
+	stateManager.SetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind), true)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -82,9 +82,9 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 
 	//Set monitoring resources exist to true
 	stateManager := common.GetStateManager()
-	stateManager.SetState(monitoringv1.PrometheusRuleKind, true)
-	stateManager.SetState(monitoringv1.ServiceMonitorsKind, true)
-	stateManager.SetState(integreatlyv1alpha1.GrafanaDashboardKind, true)
+	stateManager.SetState(getStateFieldName(monitoringv1.PrometheusRuleKind), true)
+	stateManager.SetState(getStateFieldName(monitoringv1.ServiceMonitorsKind), true)
+	stateManager.SetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind), true)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -133,9 +133,9 @@ func TestKeycloakReconciler_Test_No_Action_When_Monitoring_Resources_Dont_Exist(
 
 	//Set monitoring resources exist to true
 	stateManager := common.GetStateManager()
-	stateManager.SetState(monitoringv1.PrometheusRuleKind, false)
-	stateManager.SetState(monitoringv1.ServiceMonitorsKind, false)
-	stateManager.SetState(integreatlyv1alpha1.GrafanaDashboardKind, false)
+	stateManager.SetState(getStateFieldName(monitoringv1.PrometheusRuleKind), false)
+	stateManager.SetState(getStateFieldName(monitoringv1.ServiceMonitorsKind), false)
+	stateManager.SetState(getStateFieldName(integreatlyv1alpha1.GrafanaDashboardKind), false)
 
 	// when
 	reconciler := NewKeycloakReconciler()

--- a/pkg/controller/keycloakrealm/keycloakrealm_controller.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_controller.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -28,7 +29,7 @@ var log = logf.Log.WithName("controller_keycloakrealm")
 
 // Add creates a new KeycloakRealm Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
+func Add(mgr manager.Manager, _ chan schema.GroupVersionKind) error {
 	return add(mgr, newReconciler(mgr))
 }
 


### PR DESCRIPTION
## JIRA ID
https://issues.jboss.org/browse/INTLY-3768

## Additional Information
Two changes in this PR.
1. Statemanagement has been refactored to limit access to one at a time, which takes into account multiple go routines accessing at the same time.
2. Autodetect has now been refactored to use a Go channel. The previous implementation was tied to a specific controller which would have meant a new autodetect instance per controller, checking for the same types of resources. Now the autodetect is setup once in the operator and sends events down the channel which the controller can listen too and setup a watch on the secondary resource.

## Verification Steps
1. Start the operator locally and check the logs to see the watch has been setup for the resources that exist on the cluster.

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
