### PR TITLE
fix: Change application label to app

### DIFF
--- a/pkg/model/database_secret.go
+++ b/pkg/model/database_secret.go
@@ -13,7 +13,7 @@ func DatabaseSecret(cr *v1alpha1.Keycloak) *v1.Secret {
 			Name:      DatabaseSecretName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 		},
 		StringData: map[string]string{

--- a/pkg/model/keycloak_admin_secret.go
+++ b/pkg/model/keycloak_admin_secret.go
@@ -13,7 +13,7 @@ func KeycloakAdminSecret(cr *v1alpha1.Keycloak) *v1.Secret {
 			Name:      "credential-" + cr.Name,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application":   ApplicationName,
+				"app":           ApplicationName,
 				ApplicationName: cr.Name,
 			},
 		},

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -15,15 +15,15 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 			Name:      KeycloakDeploymentName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
-				"component":   KeycloakDeploymentComponent,
+				"app":       ApplicationName,
+				"component": KeycloakDeploymentComponent,
 			},
 		},
 		Spec: v13.StatefulSetSpec{
 			Selector: &v12.LabelSelector{
 				MatchLabels: map[string]string{
-					"application": ApplicationName,
-					"component":   KeycloakDeploymentComponent,
+					"app":       ApplicationName,
+					"component": KeycloakDeploymentComponent,
 				},
 			},
 			Template: v1.PodTemplateSpec{
@@ -31,8 +31,8 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 					Name:      KeycloakDeploymentName,
 					Namespace: cr.Namespace,
 					Labels: map[string]string{
-						"application": ApplicationName,
-						"component":   KeycloakDeploymentComponent,
+						"app":       ApplicationName,
+						"component": KeycloakDeploymentComponent,
 					},
 				},
 				Spec: v1.PodSpec{

--- a/pkg/model/keycloak_discovery_service.go
+++ b/pkg/model/keycloak_discovery_service.go
@@ -14,13 +14,13 @@ func KeycloakDiscoveryService(cr *v1alpha1.Keycloak) *v1.Service {
 			Name:      KeycloakDiscoveryServiceName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{
-				"application": ApplicationName,
-				"component":   KeycloakDeploymentComponent,
+				"app":       ApplicationName,
+				"component": KeycloakDeploymentComponent,
 			},
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -14,7 +14,7 @@ func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
 			Name:      ApplicationName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 		},
 		Spec: v1beta1.IngressSpec{

--- a/pkg/model/keycloak_route.go
+++ b/pkg/model/keycloak_route.go
@@ -14,7 +14,7 @@ func KeycloakRoute(cr *kc.Keycloak) *v1.Route {
 			Name:      ApplicationName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 			Annotations: map[string]string{
 				"haproxy.router.openshift.io/balance": RouteLoadBalancingStrategy,

--- a/pkg/model/keycloak_service.go
+++ b/pkg/model/keycloak_service.go
@@ -14,7 +14,7 @@ func KeycloakService(cr *v1alpha1.Keycloak) *v1.Service {
 			Name:      ApplicationName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 			Annotations: map[string]string{
 				"description": "The web server's https port.",
@@ -23,8 +23,8 @@ func KeycloakService(cr *v1alpha1.Keycloak) *v1.Service {
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{
-				"application": ApplicationName,
-				"component":   KeycloakDeploymentComponent,
+				"app":       ApplicationName,
+				"component": KeycloakDeploymentComponent,
 			},
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -15,15 +15,15 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 			Name:      PostgresqlDeploymentName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
-				"component":   PostgresqlDeploymentComponent,
+				"app":       ApplicationName,
+				"component": PostgresqlDeploymentComponent,
 			},
 		},
 		Spec: v13.DeploymentSpec{
 			Selector: &v12.LabelSelector{
 				MatchLabels: map[string]string{
-					"application": ApplicationName,
-					"component":   PostgresqlDeploymentComponent,
+					"app":       ApplicationName,
+					"component": PostgresqlDeploymentComponent,
 				},
 			},
 			Template: v1.PodTemplateSpec{
@@ -31,8 +31,8 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 					Name:      PostgresqlDeploymentName,
 					Namespace: cr.Namespace,
 					Labels: map[string]string{
-						"application": ApplicationName,
-						"component":   PostgresqlDeploymentComponent,
+						"app":       ApplicationName,
+						"component": PostgresqlDeploymentComponent,
 					},
 				},
 				Spec: v1.PodSpec{

--- a/pkg/model/postgresql_persistent_volume_claim.go
+++ b/pkg/model/postgresql_persistent_volume_claim.go
@@ -14,7 +14,7 @@ func PostgresqlPersistentVolumeClaim(cr *v1alpha1.Keycloak) *v1.PersistentVolume
 			Name:      PostgresqlPersistentVolumeName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{

--- a/pkg/model/postgresql_service.go
+++ b/pkg/model/postgresql_service.go
@@ -14,13 +14,13 @@ func PostgresqlService(cr *v1alpha1.Keycloak) *v1.Service {
 			Name:      PostgresqlServiceName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
+				"app": ApplicationName,
 			},
 		},
 		Spec: v1.ServiceSpec{
 			Selector: map[string]string{
-				"application": ApplicationName,
-				"component":   PostgresqlDeploymentComponent,
+				"app":       ApplicationName,
+				"component": PostgresqlDeploymentComponent,
 			},
 			Ports: []v1.ServicePort{
 				{

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -15,15 +15,15 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 			Name:      KeycloakDeploymentName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
-				"application": ApplicationName,
-				"component":   KeycloakDeploymentComponent,
+				"app":       ApplicationName,
+				"component": KeycloakDeploymentComponent,
 			},
 		},
 		Spec: v13.StatefulSetSpec{
 			Selector: &v12.LabelSelector{
 				MatchLabels: map[string]string{
-					"application": ApplicationName,
-					"component":   KeycloakDeploymentComponent,
+					"app":       ApplicationName,
+					"component": KeycloakDeploymentComponent,
 				},
 			},
 			Template: v1.PodTemplateSpec{
@@ -31,8 +31,8 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 					Name:      KeycloakDeploymentName,
 					Namespace: cr.Namespace,
 					Labels: map[string]string{
-						"application": ApplicationName,
-						"component":   KeycloakDeploymentComponent,
+						"app":       ApplicationName,
+						"component": KeycloakDeploymentComponent,
 					},
 				},
 				Spec: v1.PodSpec{

--- a/pkg/model/service_monitor.go
+++ b/pkg/model/service_monitor.go
@@ -28,7 +28,7 @@ func ServiceMonitor(cr *v1alpha1.Keycloak) *monitoringv1.ServiceMonitor {
 			}},
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"application": ApplicationName,
+					"app": ApplicationName,
 				},
 			},
 		},


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
The label on the resources should be `app` instead of `application` for them to be grouped together. Otherwise, they will show up with all other resources in a namespace.

**Old:**
![2019-10-14_10-19-39](https://user-images.githubusercontent.com/1596014/66741100-9e3a2480-ee6c-11e9-9e53-5b6464e0bc01.png)

**New:**
![2019-10-14_10-17-30](https://user-images.githubusercontent.com/1596014/66741109-a2664200-ee6c-11e9-834c-d8cc147df98b.png)




## Verification Steps
None required

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->