### PR TITLE
fix: Updating role permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -4,59 +4,96 @@ metadata:
   creationTimestamp: null
   name: keycloak-operator
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  - daemonsets
-  - replicasets
-  - statefulsets
-  verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
-- apiGroups:
-  - apps
-  resourceNames:
-  - keycloak-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - get
-- apiGroups:
-  - apps
-  resources:
-  - replicasets
-  verbs:
-  - get
-- apiGroups:
-  - keycloak.org
-  resources:
-  - '*'
-  - keycloakrealms
-  verbs:
-  - '*'
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - keycloak-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - keycloak.org
+    resources:
+      - keycloaks
+      - keycloaks/status
+      - keycloaks/finalizers
+      - keycloakrealms
+      - keycloakrealms/status
+      - keycloakrealms/finalizers
+    verbs:
+      - get
+      - list
+      - update
+      - watch


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Updating the role permissions to allow the operator to work correctly when deployed into a namespace

## Verification Steps
1. Run `make cluster/prepare`
2. Modify `operator.yaml` image to `quay.io/davidffrench/keycloak-operator:INTLY-3732`
3. Run `kubectl apply -f deploy/operator.yaml`
4. Run `kubectl apply -f deploy/examples/keycloak/keycloak.yaml
5. Ensure everything is deployed successfully

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
