### PR TITLE
Disable godox to stop the noise from GolangCI about our TODOs

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,3 +27,4 @@ linters:
     - gochecknoinits
     - gochecknoglobals
     - wsl
+    - godox


### PR DESCRIPTION
GolangCI is complaining about some of our TODOs like https://golangci.com/r/github.com/keycloak/keycloak-operator/pulls/46. I believe this just adds unnecessary noise to our PRs and should be disabled.