### PR TITLE
add cluster roles

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -1,0 +1,98 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keycloak-operator
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - services/finalizers
+      - endpoints
+      - persistentvolumeclaims
+      - events
+      - configmaps
+      - secrets
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+      - daemonsets
+      - replicasets
+      - statefulsets
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - monitoring.coreos.com
+    resources:
+      - servicemonitors
+      - prometheusrules
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - integreatly.org
+    resources:
+      - grafanadashboards
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resourceNames:
+      - keycloak-operator
+    resources:
+      - deployments/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - keycloak.org
+    resources:
+      - keycloaks
+      - keycloaks/status
+      - keycloaks/finalizers
+      - keycloakrealms
+      - keycloakrealms/status
+      - keycloakrealms/finalizers
+    verbs:
+      - get
+      - list
+      - update
+      - watch

--- a/deploy/cluster_roles/cluster_role_binding.yaml
+++ b/deploy/cluster_roles/cluster_role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: keycloak-operator
-    namespace: grafana
+    namespace: keycloak

--- a/deploy/cluster_roles/cluster_role_binding.yaml
+++ b/deploy/cluster_roles/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keycloak-operator
+roleRef:
+  name: keycloak-operator
+  kind: ClusterRole
+  apiGroup: ""
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-operator
+    namespace: grafana

--- a/deploy/examples/keycloak/rhsso.yaml
+++ b/deploy/examples/keycloak/rhsso.yaml
@@ -2,6 +2,8 @@ apiVersion: keycloak.org/v1alpha1
 kind: Keycloak
 metadata:
   name: example-keycloak
+  labels:
+    app: sso
 spec:
   instances: 1
   externalAccess:


### PR DESCRIPTION
Adding cluster roles (needed for multi namespace support).

To try out multi namespace support, first create the cluster roles:

```sh
$ oc apply -f deploy/cluster_roles
```

The modify `operator.yaml` and set an empty watch namespace...

```yaml
...
          env:
            - name: WATCH_NAMESPACE
               value: ''
...
```

...and deploy it.