### PR TITLE
Revert pruning commits

### DIFF
--- a/deploy/crds/Keycloak.yaml
+++ b/deploy/crds/Keycloak.yaml
@@ -10,7 +10,6 @@ spec:
     plural: keycloaks
     singular: keycloak
   scope: Namespaced
-  preserveUnknownFields: false
   subresources:
     status: {}
   validation:

--- a/deploy/crds/Keycloak.yaml
+++ b/deploy/crds/Keycloak.yaml
@@ -14,7 +14,6 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/crds/KeycloakRealm.yaml
+++ b/deploy/crds/KeycloakRealm.yaml
@@ -14,7 +14,6 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      type: object
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation

--- a/deploy/crds/KeycloakRealm.yaml
+++ b/deploy/crds/KeycloakRealm.yaml
@@ -10,7 +10,6 @@ spec:
     plural: keycloakrealms
     singular: keycloakrealm
   scope: Namespaced
-  preserveUnknownFields: false
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Unfortunately, the changes introduced in https://github.com/keycloak/keycloak-operator/pull/55 need to be reverted as it breaks compatibility with Kubernetes 1.11 which we need to support due to OpenShift 3.11

## Verification Steps
None needed

## Checklist:
- [x] Verified by team member
- [x] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary