### PR TITLE
feat: Allow user changes to keycloak image

### DIFF
--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -13,7 +13,7 @@ const (
 	PostgresqlImage                      = "postgres:9.5"
 	KeycloakImage                        = "quay.io/keycloak/keycloak:7.0.1"
 	KeycloakInitContainerImage           = "quay.io/keycloak/extensions-init-container:master"
-	RHSSOImage                           = "registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0"
+	RHSSOImage                           = "registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0-15"
 	BackupImage                          = "quay.io/integreatly/backup-container:1.0.10"
 	KeycloakDiscoveryServiceName         = ApplicationName + "-discovery"
 	KeycloakDeploymentName               = ApplicationName

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+
+	v13 "k8s.io/api/apps/v1"
 )
 
 // Copy pasted from https://stackoverflow.com/questions/22892120/how-to-generate-a-random-string-of-a-fixed-length-in-go
@@ -75,4 +77,14 @@ func SanitizeResourceName(name string) string {
 	}
 
 	return sb.String()
+}
+
+// Get image string from the statefulset. Default to RHSSOImage string
+func GetCurrentKeycloakImage(currentState *v13.StatefulSet) string {
+	for _, ele := range currentState.Spec.Template.Spec.Containers {
+		if ele.Name == KeycloakDeploymentName {
+			return ele.Image
+		}
+	}
+	return RHSSOImage
 }


### PR DESCRIPTION
## JIRA ID
https://issues.jboss.org/browse/INTLY-3373

## Additional Information
Use a persistent tag in the case of Keycloak and RH-SSO which negates the need for an imagestream. Also, allow the patch version to be updated without the operator reconciling back. This is to allow for CVE updates on a production cluster.

## Verification Steps
1. Create new keycloak instance using this branch
2. Modify the keycloak statefulset image to version '7.0.0' and the replicas to 3.
3. Confirm that the image version stays the same and the replicas change back to 1
4. Modify the keycloak statefulset image to version '8.0.0' 
5. Confirm the version changes back to `7.0.0`
6. Repeat steps 1-5 for rhsso

## Checklist:
- [ ] Verified by team member
- [x] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
