### PR TITLE
fix: Additional logic to correctly check version updates

### DIFF
--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -183,6 +183,8 @@ func KeycloakDeploymentSelector(cr *v1alpha1.Keycloak) client.ObjectKey {
 }
 
 func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.StatefulSet) *v13.StatefulSet {
+	currentImage := GetCurrentKeycloakImage(currentState)
+
 	reconciled := currentState.DeepCopy()
 	reconciled.ResourceVersion = currentState.ResourceVersion
 	reconciled.Spec.Replicas = SanitizeNumberOfReplicas(cr.Spec.Instances, false)
@@ -190,7 +192,7 @@ func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.State
 	reconciled.Spec.Template.Spec.Containers = []v1.Container{
 		{
 			Name:  KeycloakDeploymentName,
-			Image: getReconciledKeycloakImage(currentState),
+			Image: GetReconciledKeycloakImage(currentImage),
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: KeycloakServicePort,
@@ -354,8 +356,7 @@ func KeycloakVolumes() []v1.Volume {
 }
 
 // We allow the patch version of an image for keycloak to be increased outside of the operator on the cluster
-func getReconciledKeycloakImage(currentState *v13.StatefulSet) string {
-	currentImage := GetCurrentKeycloakImage(currentState)
+func GetReconciledKeycloakImage(currentImage string) string {
 	currentImageRepo, currentImageMajor, currentImageMinor, currentImagePatch := GetImageRepoAndVersion(currentImage)
 	keycloakImageRepo, keycloakImageMajor, keycloakImageMinor, keycloakImagePatch := GetImageRepoAndVersion(KeycloakImage)
 

--- a/pkg/model/keycloak_deployment_test.go
+++ b/pkg/model/keycloak_deployment_test.go
@@ -1,0 +1,84 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_No_Image(t *testing.T) {
+	// given
+	currentImage := ""
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_Random_Image(t *testing.T) {
+	// given
+	currentImage := "not/real/image:1.1.1"
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_No_Change(t *testing.T) {
+	// given
+	currentImage := KeycloakImage
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_Lower_Version(t *testing.T) {
+	// given
+	currentImage := "quay.io/keycloak/keycloak:6.0.0"
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_Higher_Major_Version(t *testing.T) {
+	// given
+	currentImage := "quay.io/keycloak/keycloak:100.0.1"
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_Higher_Minor_Version(t *testing.T) {
+	// given
+	currentImage := "quay.io/keycloak/keycloak:100.100.1"
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, KeycloakImage)
+}
+
+func TestUtil_Test_GetReconciledKeycloakImage_With_Higher_Patch_Version(t *testing.T) {
+	// given
+	currentImage := KeycloakImage[:len(KeycloakImage)-1] + "100"
+
+	// when
+	reconciledImage := GetReconciledKeycloakImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, currentImage)
+}

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -178,13 +178,15 @@ func RHSSODeploymentSelector(cr *v1alpha1.Keycloak) client.ObjectKey {
 }
 
 func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.StatefulSet) *v13.StatefulSet {
+	currentImage := GetCurrentKeycloakImage(currentState)
+
 	reconciled := currentState.DeepCopy()
 	reconciled.ResourceVersion = currentState.ResourceVersion
 	reconciled.Spec.Template.Spec.Volumes = KeycloakVolumes()
 	reconciled.Spec.Template.Spec.Containers = []v1.Container{
 		{
 			Name:  KeycloakDeploymentName,
-			Image: getReconciledRHSSOImage(currentState),
+			Image: GetReconciledRHSSOImage(currentImage),
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: KeycloakServicePort,
@@ -310,10 +312,9 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 }
 
 // We allow the patch version of an image for RH-SSO to be increased outside of the operator on the cluster
-func getReconciledRHSSOImage(currentState *v13.StatefulSet) string {
-	currentImage := GetCurrentKeycloakImage(currentState)
+func GetReconciledRHSSOImage(currentImage string) string {
 	currentImageRepo, currentImageMajor, currentImageMinor, currentImagePatch := GetImageRepoAndVersion(currentImage)
-	RHSSOImageRepo, RHSSOImageMajor, RHSSOImageMinor, RHSSOImagePatch := GetImageRepoAndVersion(KeycloakImage)
+	RHSSOImageRepo, RHSSOImageMajor, RHSSOImageMinor, RHSSOImagePatch := GetImageRepoAndVersion(RHSSOImage)
 
 	// Since the minor version of the RHSSO image should always be 0-X, we can ignore all before the -
 	currentImageMinorStrings := strings.Split(currentImageMinor, "-")

--- a/pkg/model/rhsso_deployment_test.go
+++ b/pkg/model/rhsso_deployment_test.go
@@ -1,0 +1,95 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_No_Image(t *testing.T) {
+	// given
+	currentImage := ""
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Random_Image(t *testing.T) {
+	// given
+	currentImage := "not/real/image:1.1.2"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_No_Change(t *testing.T) {
+	// given
+	currentImage := RHSSOImage
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Lower_Version(t *testing.T) {
+	// given
+	currentImage := "registry.access.redhat.com/redhat-sso-6/sso62-openshift:1.0-1"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Major_Version(t *testing.T) {
+	// given
+	currentImage := "registry.access.redhat.com/redhat-sso-8/sso83-openshift:1.0-15"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Minor_Version(t *testing.T) {
+	// given
+	currentImage := "registry.access.redhat.com/redhat-sso-7/sso74-openshift:1.0-15"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, RHSSOImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Patch_Version(t *testing.T) {
+	// given
+	currentImage := RHSSOImage[:len(RHSSOImage)-1] + "11"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, currentImage)
+}
+
+func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_CVE_Patch_Version(t *testing.T) {
+	// given
+	currentImage := RHSSOImage + ".1"
+
+	// when
+	reconciledImage := GetReconciledRHSSOImage(currentImage)
+
+	// then
+	assert.Equal(t, reconciledImage, currentImage)
+}

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -88,3 +88,37 @@ func GetCurrentKeycloakImage(currentState *v13.StatefulSet) string {
 	}
 	return RHSSOImage
 }
+
+// Split a full image string (e.g. quay.io/keycloak/keycloak:7.0.1 or registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0 ) into it's repo and individual versions
+func GetImageRepoAndVersion(image string) (string, string, string, string) {
+	imageRepo, imageMajor, imageMinor, imagePatch := "", "", "", ""
+
+	// Split the string on : which will leave the repo and tag
+	imageStrings := strings.Split(image, ":")
+
+	if len(imageStrings) > 0 {
+		imageRepo = imageStrings[0]
+	}
+
+	// If somehow the tag doesn't exist, return with empty strings for the versions
+	if len(imageStrings) == 1 {
+		return imageRepo, imageMajor, imageMinor, imagePatch
+	}
+
+	// Split the image tag on . to separate the version numbers
+	imageTagStrings := strings.Split(imageStrings[1], ".")
+
+	if len(imageTagStrings) > 0 {
+		imageMajor = imageTagStrings[0]
+	}
+
+	if len(imageTagStrings) > 1 {
+		imageMinor = imageTagStrings[1]
+	}
+
+	if len(imageTagStrings) > 2 {
+		imagePatch = imageTagStrings[2]
+	}
+
+	return imageRepo, imageMajor, imageMinor, imagePatch
+}

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtil_Test_GetImageRepoAndVersion_With_Valid_Keycloak_Image(t *testing.T) {
+	// given
+	image := "quay.io/keycloak/keycloak:7.0.1"
+
+	// when
+	imageRepo, imageMajor, imageMinor, imagePatch := GetImageRepoAndVersion(image)
+
+	// then
+	assert.Equal(t, imageRepo, "quay.io/keycloak/keycloak")
+	assert.Equal(t, imageMajor, "7")
+	assert.Equal(t, imageMinor, "0")
+	assert.Equal(t, imagePatch, "1")
+}
+
+func TestUtil_Test_GetImageRepoAndVersion_With_Valid_RHSSO_Image(t *testing.T) {
+	// given
+	image := "registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0-15"
+
+	// when
+	imageRepo, imageMajor, imageMinor, imagePatch := GetImageRepoAndVersion(image)
+
+	// then
+	assert.Equal(t, imageRepo, "registry.access.redhat.com/redhat-sso-7/sso73-openshift")
+	assert.Equal(t, imageMajor, "1")
+	assert.Equal(t, imageMinor, "0-15")
+	assert.Equal(t, imagePatch, "")
+}
+
+func TestUtil_Test_GetImageRepoAndVersion_With_Valid_RHSSO_CVE_Image(t *testing.T) {
+	// given
+	image := "registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0-15.1567588155"
+
+	// when
+	imageRepo, imageMajor, imageMinor, imagePatch := GetImageRepoAndVersion(image)
+
+	// then
+	assert.Equal(t, imageRepo, "registry.access.redhat.com/redhat-sso-7/sso73-openshift")
+	assert.Equal(t, imageMajor, "1")
+	assert.Equal(t, imageMinor, "0-15")
+	assert.Equal(t, imagePatch, "1567588155")
+}
+
+func TestUtil_Test_GetImageRepoAndVersion_With_No_Image(t *testing.T) {
+	// given
+	image := ""
+
+	// when
+	imageRepo, imageMajor, imageMinor, imagePatch := GetImageRepoAndVersion(image)
+
+	// then
+	assert.Equal(t, imageRepo, "")
+	assert.Equal(t, imageMajor, "")
+	assert.Equal(t, imageMinor, "")
+	assert.Equal(t, imagePatch, "")
+}


### PR DESCRIPTION
Follow on from https://github.com/keycloak/keycloak-operator/pull/64

## JIRA ID
https://issues.jboss.org/browse/INTLY-3373

## Additional Information
Adding additional logic based on an excellent observation from @slaskawi that would mean operator upgrades with a new operand version would not take effect.

## Verification Steps
1. Create new keycloak instance using this branch
2. Modify the keycloak statefulset image to version '7.0.0' and the replicas to 3.
3. Confirm that the image version stays the same and the replicas change back to 1
4. Modify the keycloak statefulset image to version '8.0.0'
5. Confirm the version changes back to 7.0.0
6. Repeat steps 1-5 for rhsso

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
