### PR TITLE
fix: Remove structural schema from CRD

### DIFF
--- a/deploy/crds/KeycloakBackup.yaml
+++ b/deploy/crds/KeycloakBackup.yaml
@@ -69,7 +69,6 @@ spec:
                   type: string
         status:
           type: object
-      type: object
   version: v1alpha1
   versions:
   - name: v1alpha1


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Removing type filed from KeycloakBackup CRD so it can be applied to Kubernetes 1.11