### PR TITLE
feat: Upgrade Postgres to 11.5

### DIFF
--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -10,7 +10,7 @@ const (
 	PostgresqlDeploymentName             = ApplicationName + "-postgresql"
 	PostgresqlDeploymentComponent        = "database"
 	PostgresqlServiceName                = ApplicationName + "-postgresql"
-	PostgresqlImage                      = "postgres:9.5"
+	PostgresqlImage                      = "postgres:11.5"
 	KeycloakImage                        = "quay.io/keycloak/keycloak:7.0.1"
 	KeycloakInitContainerImage           = "quay.io/keycloak/extensions-init-container:master"
 	RHSSOImage                           = "registry.access.redhat.com/redhat-sso-7/sso73-openshift:1.0-15"


### PR DESCRIPTION
## JIRA ID
[KEYCLOAK-12259](https://issues.jboss.org/browse/KEYCLOAK-12259)

## Additional Information
Based on a mail thread, Postgres should be updated to 10.1 but this is not working with OpenShift due to permissions. It is working with 11.5 but we need confirmation we can upgrade to this.

## Verification Steps
1. Create Keycloak instance from this branch
2. Run any other tests you think are required.

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
