### PR TITLE
fix: Update PromRule name to reflect query

### DIFF
--- a/pkg/model/prometheus_rule.go
+++ b/pkg/model/prometheus_rule.go
@@ -103,7 +103,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 						"severity": "critical",
 					},
 				}, {
-					Alert: "KeycloakAPIRequestDuration99PercThresholdExceeded",
+					Alert: "KeycloakAPIRequestDuration99.5PercThresholdExceeded",
 					Annotations: map[string]string{
 						"message": `Less than 99.5% of the RH SSO API endpoints in namespace {{ $labels.namespace }} are taking longer than 10s for the last 5 minutes.`,
 					},


### PR DESCRIPTION
## JIRA ID
https://issues.jboss.org/browse/INTLY-3774

## Additional Information
The KeycloakAPIRequestDuration99PercThresholdExceeded alerts is checking that 99.5% of requests are being served within 10 seconds over a period of 5 minutes, but the alert name states that this percentage is 99%:

## Verification Steps
None required. it is just a name change

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
