### PR TITLE
fix: Adding permissions for cronjobs and jobs

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -34,6 +34,17 @@ rules:
       - update
       - watch
   - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
       - route.openshift.io
     resources:
       - routes
@@ -91,6 +102,9 @@ rules:
       - keycloakrealms
       - keycloakrealms/status
       - keycloakrealms/finalizers
+      - keycloakbackups
+      - keycloakbackups/status
+      - keycloakbackups/finalizers
     verbs:
       - get
       - list

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -35,6 +35,17 @@ rules:
       - update
       - watch
   - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - list
+      - get
+      - create
+      - update
+      - watch
+  - apiGroups:
       - route.openshift.io
     resources:
       - routes
@@ -92,6 +103,9 @@ rules:
       - keycloakrealms
       - keycloakrealms/status
       - keycloakrealms/finalizers
+      - keycloakbackups
+      - keycloakbackups/status
+      - keycloakbackups/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
## JIRA ID
None

## Additional Information
Operator is broken without this change. Using the operator on the cluster was not working due to missing permissions for jobs, cronjobs and keycloakbackups in the role

## Verification Steps
1. Run the operator from an image in the cluster using the rbac applied from this branch.

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
