### PR TITLE
[PROPOSAL] Enhancements to the Makefile and Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 # Other contants
 NAMESPACE=keycloak
+VERSION=7.0.1
 PROJECT=keycloak-operator
 PKG=github.com/keycloak/keycloak-operator
 OPERATOR_SDK_VERSION=v0.10.0
 OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu
 MINIKUBE_DOWNLOAD_URL=https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-linux-amd64
 KUBECTL_DOWNLOAD_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl
+GIT_COMMIT=$(shell git --no-pager describe --always --dirty)
+TIMESTAMP=$(shell date --utc +%Y%m%d_%H%M%SZ)
+LFLAGS ?= -X main.commitID=${GIT_COMMIT} -X main.timestamp=${TIMESTAMP} -X main.buildVersion=${VERSION}
 
 # Compile constants
 COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
@@ -103,7 +107,7 @@ code/run:
 
 .PHONY: code/compile
 code/compile:
-	@GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -o=$(COMPILE_TARGET) -mod=vendor ./cmd/manager
+	@GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=${CGO_ENABLED} go build -ldflags "${LFLAGS}" -o=$(COMPILE_TARGET) -mod=vendor ./cmd/manager
 
 .PHONY: code/gen
 code/gen:

--- a/Makefile
+++ b/Makefile
@@ -156,3 +156,16 @@ test/goveralls: test/coverage/prepare
 	go get -u github.com/mattn/goveralls
 	@echo "Running goveralls"
 	@goveralls -v -coverprofile=cover-all.coverprofile -service=travis-ci
+
+.PHONY: docker/build
+docker/build:
+	@echo "Building Docker image"
+	docker build --no-cache -t ${NAMESPACE}/${PROJECT}:${VERSION} -f build/Dockerfile
+	@echo "Docker image ${NAMESPACE}/${PROJECT}"
+
+.PHONY: docker/release/prepare
+docker/release/prepare:
+	@echo "Prepare for a release of ${PROJECT}"
+	@sed -ie 's/CACHE_BUST=.*/CACHE_BUST=${TIMESTAMP}/' build/Dockerfile
+	@git add build/Dockerfile
+	@git commit -m "Prepare for release version: ${VERSION} (git+sha: ${GIT_COMMIT}, built: ${TIMESTAMP}"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,14 +9,10 @@ ENV OPERATOR=/usr/local/bin/keycloak-operator \
     USER_UID=1001 \
     USER_NAME=keycloak-operator
 
-ENV SHA1_FILE=/BUILD_SHA1.txt
-ENV BUILD_DATE_FILE=/BUILD_DATE.txt
 # Because of https://github.com/containers/buildah/issues/1906
 # We need to increment this variable whenever we need a rebuild.
 # The fix should be implemented very soon
 ENV CACHE_BUST=1
-
-RUN echo "$(date)" > $BUILD_DATE_FILE
 
 COPY tools /opt/jboss/tools
 RUN /opt/jboss/tools/build-operator.sh

--- a/build/tools/build-operator.sh
+++ b/build/tools/build-operator.sh
@@ -25,5 +25,5 @@ curl https://storage.googleapis.com/golang/go$VERSION.linux-amd64.tar.gz | tar -
 git clone --depth 1 $GIT_REPO $KEYCLOAK_PATH/keycloak-operator
 
 # Build and copy the binary
-cd /go/src/github.com/keycloak/keycloak-operator && echo "Build SHA1: $(git rev-parse HEAD)" | tee ${SHA1_FILE} && make code/compile
+cd /go/src/github.com/keycloak/keycloak-operator && make code/compile
 cp ./tmp/_output/bin/keycloak-operator /usr/local/bin

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/keycloak/keycloak-operator/version"
-
 	"github.com/keycloak/keycloak-operator/pkg/common"
 	routev1 "github.com/openshift/api/route/v1"
 
@@ -47,11 +45,18 @@ var (
 )
 var log = logf.Log.WithName("cmd")
 
+// Retrieve the information during the build time
+var (
+	commitID     = "no Git Hash provided"
+	timestamp    = "0"
+	buildVersion = "0"
+)
+
 func printVersion() {
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
-	log.Info(fmt.Sprintf("Operator version: %v", version.Version))
+	log.Info(fmt.Sprintf("Operator version: %v (git+sha: %s, built: %s)", buildVersion, commitID, timestamp))
 }
 
 func main() {

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,6 @@
 package version
 
+//TODO Check if we can remove it
 var (
 	Version = "7.0.1"
 )


### PR DESCRIPTION
## PROPOSAL
This PR is **not** intended to be merged before the first release of the new Operator and the goal is to provide small enhancements to overcome issues with cache on quay.io or during development. 

It was split into 3 separate commits, so if there's any disagreement we can just get rid of some of them or all of them :)

## Additional Information
* Removal of the previous approach to overcome issues with caching
* Enhancements to the Makefile

    When building the Docker image with Podman or on quay.io the shell script
    will be cached as we found out during the development.

    This kind of situation is not obvious for this reason was added:
    - docker/build: builds the Docker image and tag it for developers willing to use it locally
    - docker/release/prepare: to workaround the caching issues on quay.io Sebastian found out that we need to update an
    env variable at each release, until quay.io, fixes it or provides alternatives to disable cache.

* Small enhancements to the build

    The goal of this commit is to provide developers some guidance when struggling with caching. By adding these flags, people are able to know exactly which commit id the Keycloak Operator was built and when.
   Also, the Version of the Operator was moved to the Makefile, so we can
reuse it to build our Docker image

## Verification Steps
* Run `make docker/build` several times and verify that nothing is being cached
* Run `make docker/release/prepare` and verify the commit message: `Prepare for release version: 7.0.1 (git+sha: cd55b24, built: 20191114_215444Z)`

## Notes
* Kudos to @slaskawi  for finding the culprit of the issue
* This is not a definitive fix, it's just a proposal to not go crazy during the development
* Ideally quay.io should provide a way to disable cache