### PR TITLE
KEYCLOAK-12408 Lock UBI Image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS build-env
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 AS build-env
 
 RUN microdnf install -y git make golang
 
@@ -8,7 +8,7 @@ RUN cd /src && echo "Build SHA1: $(git rev-parse HEAD)"
 RUN cd /src && echo "$(git rev-parse HEAD)" > /src/BUILD_INFO
 
 # final stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
 
 ENV OPERATOR=/usr/local/bin/keycloak-operator \
     USER_UID=1001 \


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
[KEYCLOAK-12408](https://issues.redhat.com/browse/KEYCLOAK-12408)

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
Here's an output from Skopeo:

```
$ skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal
{
    "Name": "registry.access.redhat.com/ubi8/ubi-minimal",
    "Digest": "sha256:32fb8bae553bfba2891f535fa9238f79aafefb7eff603789ba8920f505654607",
    "RepoTags": [
        "8.1",
        "8.0",
        "8.0-204",
        "8.0-213",
        "8.0-159",
        "8.0-127",
        "8.1-279",
        "latest",
        "8.0-131"
    ],
    "Created": "2019-10-29T16:44:32.524013Z",
    "DockerVersion": "1.13.1",
    "Labels": {
        "architecture": "x86_64",
        "authoritative-source-url": "registry.access.redhat.com",
        "build-date": "2019-10-29T16:44:07.247612",
        "com.redhat.build-host": "cpt-1006.osbs.prod.upshift.rdu2.redhat.com",
        "com.redhat.component": "ubi8-minimal-container",
        "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
        "description": "The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
        "distribution-scope": "public",
        "io.k8s.description": "The Universal Base Image Minimal is a stripped down image that uses microdnf as a package manager. This base image is freely redistributable, but Red Hat only supports Red Hat technologies through subscriptions for Red Hat products. This image is maintained by Red Hat and updated regularly.",
        "io.k8s.display-name": "Red Hat Universal Base Image 8 Minimal",
        "io.openshift.expose-services": "",
        "io.openshift.tags": "minimal rhel8",
        "maintainer": "Red Hat, Inc.",
        "name": "ubi8-minimal",
        "release": "279",
        "summary": "Provides the latest release of the minimal Red Hat Universal Base Image 8.",
        "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.1-279",
        "vcs-ref": "fdfa536a6288731283f8c7931bd3e09fa176bf0f",
        "vcs-type": "git",
        "vendor": "Red Hat, Inc.",
        "version": "8.1"
    },
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:645c2831c08a549f2c2aa45a92ec5096a846ffe2446b47b4c1ee42ed2311e966",
        "sha256:5e98065763a53ef594db71e034358f19da822551ade68ca27199f346761e085a"
    ]
}
```


## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->