### PR TITLE
KEYCLOAK-12409 - Makes image configurable

### DIFF
--- a/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakbackups_crd.yaml
@@ -69,6 +69,13 @@ spec:
                 flag to true. Potentially, it will be possible to restore a single
                 backup multiple times."
               type: boolean
+            container:
+              type: object
+              description: Additional container configuration
+              properties:
+                image:
+                  description: The full Docker tag of the backup image to use
+                  type: string
           type: object
         status:
           description: KeycloakBackupStatus defines the observed state of KeycloakBackup

--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -75,6 +75,20 @@ spec:
               description: Profile used for controlling Operator behavior. Default
                 is empty.
               type: string
+            container:
+              type: object
+              description: Container spec
+              properties:
+                image:
+                  type: string
+                  description: The full Docker image tag (repo/image:tag) to use
+            initContainer:
+              type: object
+              description: Initcontainer details
+              properties:
+                image:
+                  type: string
+                  description: The full Docker image tag (repo/image:tag) for the initcontainer
           type: object
         status:
           description: KeycloakStatus defines the observed state of Keycloak

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -51,7 +51,7 @@ type KeycloakSpec struct {
 	Profile string `json:"profile,omitempty"`
 	// Image is the full docker tag of the keycloak image to use
 	Container KeycloakContainer `json:"container,omitempty"`
-	// InitContainer has informtion about the image tag to use
+	// InitContainer has information about the image tag to use
 	InitContainer KeycloakContainer `json:"initContainer,omitempty"`
 }
 

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -49,6 +49,14 @@ type KeycloakSpec struct {
 	// Profile used for controlling Operator behavior. Default is empty.
 	// +optional
 	Profile string `json:"profile,omitempty"`
+	// Image is the full docker tag of the keycloak image to use
+	Container KeycloakContainer `json:"container,omitempty"`
+	// InitContainer has informtion about the image tag to use
+	InitContainer KeycloakContainer `json:"initContainer,omitempty"`
+}
+
+type KeycloakContainer struct {
+	Image string `json:"image,omitempty"`
 }
 
 type KeycloakExternalAccess struct {

--- a/pkg/apis/keycloak/v1alpha1/keycloakbackup_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakbackup_types.go
@@ -22,6 +22,8 @@ type KeycloakBackupSpec struct {
 	// Persistent Volume backup will be chosen.
 	// +optional
 	AWS KeycloakAWSSpec `json:"aws,omitempty"`
+	// If provided, overrides container information
+	Container KeycloakContainer `json:"container,omitempty"`
 }
 
 // KeycloakAWSSpec defines the desired state of KeycloakBackupSpec

--- a/pkg/model/init_container_common.go
+++ b/pkg/model/init_container_common.go
@@ -7,11 +7,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func KeycloakInitContainerImageFullTag(cr *v1alpha1.Keycloak) string {
+	if cr.Spec.InitContainer.Image != "" {
+		return cr.Spec.InitContainer.Image
+	}
+	return KeycloakInitContainerImage
+}
+
 func KeycloakExtensionsInitContainers(cr *v1alpha1.Keycloak) []v1.Container {
 	return []v1.Container{
 		{
 			Name:  "extensions-init",
-			Image: KeycloakInitContainerImage,
+			Image: KeycloakInitContainerImageFullTag(cr),
 			Env: []v1.EnvVar{
 				{
 					Name:  KeycloakExtensionEnvVar,

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -11,6 +11,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// KeycloakImageFullTag returns the desired Keycloak image
+func KeycloakImageFullTag(cr *v1alpha1.Keycloak) string {
+	if cr.Spec.Container.Image != "" {
+		return cr.Spec.Container.Image
+	}
+	return KeycloakImage
+}
+
 func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 	return &v13.StatefulSet{
 		ObjectMeta: v12.ObjectMeta{
@@ -44,7 +52,7 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 					Containers: []v1.Container{
 						{
 							Name:  KeycloakDeploymentName,
-							Image: KeycloakImage,
+							Image: KeycloakImageFullTag(cr),
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: KeycloakServicePort,

--- a/pkg/model/postgresql_common_backup.go
+++ b/pkg/model/postgresql_common_backup.go
@@ -5,11 +5,18 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+func KeycloakBackupImageName(cr *v1alpha1.KeycloakBackup) string {
+	if cr.Spec.Container.Image != "" {
+		return cr.Spec.Container.Image
+	}
+	return BackupImage
+}
+
 func postgresqlAwsBackupCommonContainers(cr *v1alpha1.KeycloakBackup) []v1.Container {
 	return []v1.Container{
 		{
 			Name:    cr.Name,
-			Image:   BackupImage,
+			Image:   KeycloakBackupImageName(cr),
 			Command: []string{"/opt/intly/tools/entrypoint.sh", "-c", "postgres", "-n", cr.Namespace, "-b", "s3", "-e", ""},
 			Env: []v1.EnvVar{
 				{

--- a/pkg/model/rhsso_deployment_test.go
+++ b/pkg/model/rhsso_deployment_test.go
@@ -3,15 +3,24 @@ package model
 import (
 	"testing"
 
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	"github.com/stretchr/testify/assert"
 )
+
+var mockKC = v1alpha1.Keycloak{
+	Spec: v1alpha1.KeycloakSpec{
+		Container: v1alpha1.KeycloakContainer{
+			Image: RHSSOImage,
+		},
+	},
+}
 
 func TestUtil_Test_GetReconciledRHSSOImage_With_No_Image(t *testing.T) {
 	// given
 	currentImage := ""
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -22,7 +31,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Random_Image(t *testing.T) {
 	currentImage := "not/real/image:1.1.2"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -33,7 +42,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_No_Change(t *testing.T) {
 	currentImage := RHSSOImage
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -44,7 +53,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Lower_Version(t *testing.T) {
 	currentImage := "registry.access.redhat.com/redhat-sso-6/sso62-openshift:1.0-1"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -55,7 +64,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Major_Version(t *testing.
 	currentImage := "registry.access.redhat.com/redhat-sso-8/sso83-openshift:1.0-15"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -66,7 +75,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Minor_Version(t *testing.
 	currentImage := "registry.access.redhat.com/redhat-sso-7/sso74-openshift:1.0-15"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, RHSSOImage)
@@ -77,7 +86,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_Patch_Version(t *testing.
 	currentImage := RHSSOImage[:len(RHSSOImage)-1] + "11"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, currentImage)
@@ -88,7 +97,7 @@ func TestUtil_Test_GetReconciledRHSSOImage_With_Higher_CVE_Patch_Version(t *test
 	currentImage := RHSSOImage + ".1"
 
 	// when
-	reconciledImage := GetReconciledRHSSOImage(currentImage)
+	reconciledImage := GetReconciledRHSSOImage(&mockKC, currentImage)
 
 	// then
 	assert.Equal(t, reconciledImage, currentImage)


### PR DESCRIPTION
Our use case is a fork of the specified image that includes custom themes, etc.

## JIRA ID
  * https://issues.redhat.com/browse/KEYCLOAK-12409
  * https://issues.redhat.com/browse/KEYCLOAK-12410

## Additional Information
I found issue #12409 after re-working some of this code, and so instead of `imageOverrides`, I opted to mirror the standard Kubernetes `container` struct - currently with `container.image` only - in anticipation of extra environment vars (see 12397), commands, etc.

## Verification Steps

Tested against a CRD like the following:
```
apiVersion: keycloak.org/v1alpha1
kind: Keycloak
metadata:
  name: example-keycloak
  labels:
    app: sso
spec:
  instances: 1
  extensions:
    - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
  externalAccess:
    enabled: True
  container:
    image: 1234567890.amazonaws.com/my-custom-image:tag
  initContainer:
    image: 1234567890.amazonaws.com/my-custom-init-container-image:tag
```

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->