### PR TITLE
KEYCLOAK-12449: Fix internal keycloak URL.

### DIFF
--- a/pkg/controller/keycloak/keycloak_controller.go
+++ b/pkg/controller/keycloak/keycloak_controller.go
@@ -227,8 +227,9 @@ func (r *ReconcileKeycloak) ManageSuccess(instance *v1alpha1.Keycloak, currentSt
 	if currentState.KeycloakRoute != nil && currentState.KeycloakRoute.Spec.Host != "" {
 		instance.Status.InternalURL = fmt.Sprintf("https://%v", currentState.KeycloakRoute.Spec.Host)
 	} else if currentState.KeycloakService != nil && currentState.KeycloakService.Spec.ClusterIP != "" {
-		instance.Status.InternalURL = fmt.Sprintf("http://%v:%v",
-			currentState.KeycloakService.Spec.ClusterIP,
+		instance.Status.InternalURL = fmt.Sprintf("https://%v.%v.svc:%v",
+			currentState.KeycloakService.Name,
+			currentState.KeycloakService.Namespace,
 			model.KeycloakServicePort)
 	}
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Stolen from https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/util.go
@@ -49,4 +50,8 @@ func WaitForPersistentVolumeClaimCreated(t *testing.T, c kubernetes.Interface, p
 
 func Create(f *framework.Framework, obj runtime.Object, ctx *framework.TestCtx) error {
 	return f.Client.Create(context.TODO(), obj, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+}
+
+func Get(f *framework.Framework, key dynclient.ObjectKey, obj runtime.Object, ctx *framework.TestCtx) error {
+	return f.Client.Get(context.TODO(), key, obj)
 }


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-12449

## Additional Information
The operator failed to sync CRs into its keycloak cluster using the
service since it used http and the service's IP on keycloak's SSL port.
This is a blocker - especially in non-openshift clusters without Route
CRD support.
This PR makes the operator use https and the service's name instead.

## Verification Steps
see https://issues.redhat.com/browse/KEYCLOAK-12449

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [x] Automated Tests
- [x] Documentation changes if necessary - not necessary