### PR TITLE
KEYCLOAK-12807 add options for audit logging

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -60,8 +60,8 @@ spec:
                           type: string
                         type: array
                     required:
-                    - key
-                    - operator
+                      - key
+                      - operator
                     type: object
                   type: array
                 matchLabels:
@@ -215,7 +215,7 @@ spec:
                           type: string
                         type: array
                     required:
-                    - clientId
+                      - clientId
                     type: object
                   type: array
                 displayName:
@@ -359,7 +359,7 @@ spec:
                     type: object
                   type: array
               required:
-              - realm
+                - realm
               type: object
             realmOverrides:
               description: A list of overrides to the default Realm behavior.
@@ -373,8 +373,17 @@ spec:
                     type: string
                 type: object
               type: array
+            eventsEnabled:
+              description: Enable events recording
+              type: boolean
+            adminEventsEnabled:
+              description: Enable admin events recording
+              type: boolean
+            adminEventsDetailsEnabled:
+              description: Enable admin events details
+              type: boolean
           required:
-          - realm
+            - realm
           type: object
         status:
           description: KeycloakRealmStatus defines the observed state of KeycloakRealm
@@ -403,14 +412,14 @@ spec:
                 ]'
               type: object
           required:
-          - loginURL
-          - message
-          - phase
-          - ready
+            - loginURL
+            - message
+            - phase
+            - ready
           type: object
       type: object
   version: v1alpha1
   versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+    - name: v1alpha1
+      served: true
+      storage: true

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -43,6 +43,18 @@ type KeycloakAPIRealm struct {
 	// A set of Event Listeners.
 	// +optional
 	EventsListeners []string `json:"eventsListeners,omitempty"`
+	// Enable events recording
+	// TODO: change to values and use kubebuilder default annotation once supported
+	// +optional
+	EventsEnabled *bool `json:"eventsEnabled,omitempty"`
+	// Enable events recording
+	// TODO: change to values and use kubebuilder default annotation once supported
+	// +optional
+	AdminEventsEnabled *bool `json:"adminEventsEnabled,omitempty"`
+	// Enable admin events details
+	// TODO: change to values and use kubebuilder default annotation once supported
+	// +optional
+	AdminEventsDetailsEnabled *bool `json:"adminEventsDetailsEnabled,omitempty"`
 }
 
 type RedirectorIdentityProviderOverride struct {

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -206,6 +206,21 @@ func (in *KeycloakAPIRealm) DeepCopyInto(out *KeycloakAPIRealm) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EventsEnabled != nil {
+		in, out := &in.EventsEnabled, &out.EventsEnabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.AdminEventsEnabled != nil {
+		in, out := &in.AdminEventsEnabled, &out.AdminEventsEnabled
+		*out = new(bool)
+		**out = **in
+	}
+	if in.AdminEventsDetailsEnabled != nil {
+		in, out := &in.AdminEventsDetailsEnabled, &out.AdminEventsDetailsEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/keycloakrealm/keycloakrealm_reconciler_test.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_reconciler_test.go
@@ -26,10 +26,13 @@ func getDummyRealm() *v1alpha1.KeycloakRealm {
 				},
 			},
 			Realm: &v1alpha1.KeycloakAPIRealm{
-				ID:          "dummy",
-				Realm:       "dummy",
-				Enabled:     true,
-				DisplayName: "dummy",
+				ID:                        "dummy",
+				Realm:                     "dummy",
+				Enabled:                   true,
+				DisplayName:               "dummy",
+				EventsEnabled:             &[]bool{true}[0],
+				AdminEventsEnabled:        &[]bool{true}[0],
+				AdminEventsDetailsEnabled: &[]bool{true}[0],
 				Users: []*v1alpha1.KeycloakAPIUser{
 					{
 						ID:        "dummy",
@@ -80,6 +83,10 @@ func TestKeycloakRealmReconciler_Reconcile(t *testing.T) {
 	assert.IsType(t, &common.CreateRealmAction{}, desiredState[1])
 	assert.IsType(t, &common.GenericCreateAction{}, desiredState[2])
 	assert.IsType(t, &common.ConfigureRealmAction{}, desiredState[3])
+
+	assert.True(t, *realm.Spec.Realm.EventsEnabled)
+	assert.True(t, *realm.Spec.Realm.AdminEventsEnabled)
+	assert.True(t, *realm.Spec.Realm.AdminEventsDetailsEnabled)
 
 	state.Realm = realm
 


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/INTLY-4404 (converted to Keycloak JIRA)
https://issues.redhat.com/browse/KEYCLOAK-12807

## Additional Information
Enable audit logging by default for realms created by the operator. This will enable recording of Admin Events, Login Events and JSON representations for Admin Events.

The list of events will look like this:

![screenshot](https://user-images.githubusercontent.com/1851198/72611953-b3bb6080-392b-11ea-8782-6fccccde8003.png)


## Verification Steps

1. Deploy keycloak using the operator from this branch
1. Create a realm and don't specify any additional parameters in the CR
1. Open the realm in the admin console and navigate to `Events > Config`
1. Both Login and Admin Events should be enabled and Include Representation should be enabled for Admin Events.

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary
