### PR TITLE
Extra volumes

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -87,7 +87,7 @@ spec:
               items:
                 type: string
                 description: A secret to be mounted as a volume in the keycloak pod
-            configmaps:
+            configMaps:
               type: array
               items:
                 type: string

--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -82,6 +82,16 @@ spec:
                 Profile used for controlling Operator behavior. Default
                 is empty.
               type: string
+            secrets:
+              type: array
+              items:
+                type: string
+                description: A secret to be mounted as a volume in the keycloak pod
+            configmaps:
+              type: array
+              items:
+                type: string
+                description: A configmap to be mounted as a volume in the keycloak pod
           type: object
         status:
           description: KeycloakStatus defines the observed state of Keycloak

--- a/docs/README.asciidoc
+++ b/docs/README.asciidoc
@@ -2,9 +2,14 @@
 
 === KeycloakClient Custom Resource Definition (CRD)
 
-Clients are entities that can request authentication of a user. Clients come in two forms. The first type of client is an application that wants to participate in single-sign-on. These clients just want Keycloak to provide security for them. The other type of client is one that is requesting an access token so that it can invoke other services on behalf of the authenticated user. 
+Clients are entities that can request authentication of a user.
+Clients come in two forms.
+The first type of client is an application that wants to participate in single-sign-on.
+These clients just want Keycloak to provide security for them.
+The other type of client is one that is requesting an access token so that it can invoke other services on behalf of the authenticated user.
 
-The Keycloak Operator allows application developers to represent Keycloak Clients as Custom Resources. Learn how to create your own KeycloakClient CRD here
+The Keycloak Operator allows application developers to represent Keycloak Clients as Custom Resources.
+Learn how to create your own KeycloakClient CRD here
 
 * link:keycloak-client.asciidoc[KeycloakClient Custom Resource]
 
@@ -16,9 +21,12 @@ Additional information about Keycloak Client can be found here
 
 === KeycloakUser Custom Resource Definition (CRD)
 
-Users are entities that are able to log into your system. They can have attributes associated with themselves like email, username, address, phone number, and birth day. They can be assigned group membership and have specific roles assigned to them.
+Users are entities that are able to log into your system.
+They can have attributes associated with themselves like email, username, address, phone number, and birth day.
+They can be assigned group membership and have specific roles assigned to them.
 
-The Keycloak Operator allows application developers to configure Keycloak Users as Custom Resources. Learn how to create your own KeycloakUser CRD here
+The Keycloak Operator allows application developers to configure Keycloak Users as Custom Resources.
+Learn how to create your own KeycloakUser CRD here
 
 * link:keycloak-user.asciidoc[KeycloakUser Custom Resource]
 
@@ -40,6 +48,13 @@ Learn how to create your own KeycloakBackup CRD here
 
 === Using external database
 
-The Keycloak Operator allows application developers to utilize an external Postgres database. Learn how to connect an external Postgres database to your KeycloakClient here
+The Keycloak Operator allows application developers to utilize an external Postgres database.
+Learn how to connect an external Postgres database to your KeycloakClient here
 
 * link:external-database.asciidoc[Using external database]
+
+=== Mounting secrets or config maps
+
+The Keycloak Operator allows to mount secrets or config maps into the Keycloak pod.
+
+* link:extra-volumes.asciidoc[Mounting secrets or config maps]

--- a/docs/extra-volumes.asciidoc
+++ b/docs/extra-volumes.asciidoc
@@ -1,0 +1,20 @@
+= Mounting secrets or configmaps
+
+Secrets and Config Maps can be mounted into the Keycloak pod by listing them in the CR, e.g.
+
+```yaml
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: example-keycloak
+  labels:
+    app: sso
+spec:
+  instances: 1
+  secrets:
+    - a-secret
+  configMaps:
+    - a-configmap
+```
+
+Secrets will be mounted under `/etc/keycloak-secrets/secret-<secret name>` and config maps under `/etc/keycloak-configmaps/configmap-<config map name>`.

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -49,6 +49,12 @@ type KeycloakSpec struct {
 	// Profile used for controlling Operator behavior. Default is empty.
 	// +optional
 	Profile string `json:"profile,omitempty"`
+	// Secrets to be mounted as volumes in the keycloak pod.
+	// +optional
+	Secrets []string `json:"secrets,omitempty"`
+	// Config maps to be mounted as volumes in the keycloak pod.
+	// +optional
+	ConfigMaps []string `json:"configMaps,omitempty"`
 }
 
 type KeycloakExternalAccess struct {

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -784,6 +784,16 @@ func (in *KeycloakSpec) DeepCopyInto(out *KeycloakSpec) {
 	}
 	out.ExternalAccess = in.ExternalAccess
 	out.ExternalDatabase = in.ExternalDatabase
+	if in.Secrets != nil {
+		in, out := &in.Secrets, &out.Secrets
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.ConfigMaps != nil {
+		in, out := &in.ConfigMaps, &out.ConfigMaps
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -79,9 +79,17 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 
 	// 4 volumes are expected: Certs, Extensions, test configmap and test secret
 	assert.Len(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes, 4)
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes[0].Name, model.ServingCertSecretName)
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes[1].Name, "keycloak-extensions")
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes[2].Name, "secret-test")
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes[3].Name, "configmap-test")
 
 	// 4 volume mounts are expected: Certs, Extensions, test configmap and test secret
 	assert.Len(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts, 4)
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts[0].Name, model.ServingCertSecretName)
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts[1].Name, "keycloak-extensions")
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts[2].Name, "secret-test")
+	assert.Equal(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts[3].Name, "configmap-test")
 }
 
 func TestKeycloakReconciler_Test_Creating_RHSSO(t *testing.T) {

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -22,6 +22,8 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	cr.Spec.ExternalAccess = v1alpha1.KeycloakExternalAccess{
 		Enabled: true,
 	}
+	cr.Spec.Secrets = []string{"test"}
+	cr.Spec.ConfigMaps = []string{"test"}
 
 	currentState := common.NewClusterState()
 
@@ -74,6 +76,12 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[10].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakRoute(cr), desiredState[11].(common.GenericCreateAction).Ref)
+
+	// 4 volumes are expected: Certs, Extensions, test configmap and test secret
+	assert.Len(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Volumes, 4)
+
+	// 4 volume mounts are expected: Certs, Extensions, test configmap and test secret
+	assert.Len(t, model.KeycloakDeployment(cr).Spec.Template.Spec.Containers[0].VolumeMounts, 4)
 }
 
 func TestKeycloakReconciler_Test_Creating_RHSSO(t *testing.T) {

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -44,4 +44,6 @@ const (
 	ClientSecretName                      = ApplicationName + "-client-secret"
 	ClientSecretClientIDProperty          = "CLIENT_ID"
 	ClientSecretClientSecretProperty      = "CLIENT_SECRET"
+	SecretsMountDir                       = "/etc/keycloak-secrets/"
+	ConfigMapsMountDir                    = "/etc/keycloak-configmaps/"
 )

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -44,6 +44,7 @@ const (
 	ClientSecretName                      = ApplicationName + "-client-secret"
 	ClientSecretClientIDProperty          = "CLIENT_ID"
 	ClientSecretClientSecretProperty      = "CLIENT_SECRET"
-	SecretsMountDir                       = "/etc/keycloak-secrets/"
-	ConfigMapsMountDir                    = "/etc/keycloak-configmaps/"
+	SecretsMountDir                       = "/etc/keycloak-secrets/"    // nolint
+	ConfigMapsMountDir                    = "/etc/keycloak-configmaps/" // nolint
+	DefaultVolumesArraySize               = 2
 )

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -323,7 +323,9 @@ func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.State
 }
 
 func KeycloakVolumeMounts(cr *v1alpha1.Keycloak, extensionsPath string) []v1.VolumeMount {
-	var mounts []v1.VolumeMount
+	// var mounts []v1.VolumeMount
+	len := DefaultVolumesArraySize + len(cr.Spec.Secrets) + len(cr.Spec.ConfigMaps)
+	mounts := make([]v1.VolumeMount, 0, len)
 
 	// Certificates
 	mounts = append(mounts, v1.VolumeMount{
@@ -360,7 +362,8 @@ func KeycloakVolumeMounts(cr *v1alpha1.Keycloak, extensionsPath string) []v1.Vol
 }
 
 func KeycloakVolumes(cr *v1alpha1.Keycloak) []v1.Volume {
-	var volumes []v1.Volume
+	len := DefaultVolumesArraySize + len(cr.Spec.Secrets) + len(cr.Spec.ConfigMaps)
+	volumes := make([]v1.Volume, 0, len)
 	var volumeOptional = true
 
 	// Certificates
@@ -410,7 +413,6 @@ func KeycloakVolumes(cr *v1alpha1.Keycloak) []v1.Volume {
 				},
 			},
 		})
-
 	}
 
 	return volumes

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -40,7 +40,7 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 					},
 				},
 				Spec: v1.PodSpec{
-					Volumes:        KeycloakVolumes(),
+					Volumes:        KeycloakVolumes(cr),
 					InitContainers: KeycloakExtensionsInitContainers(cr),
 					Containers: []v1.Container{
 						{
@@ -140,7 +140,7 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 									},
 								},
 							},
-							VolumeMounts: KeycloakVolumeMounts(RhssoExtensionPath),
+							VolumeMounts: KeycloakVolumeMounts(cr, RhssoExtensionPath),
 							LivenessProbe: &v1.Probe{
 								InitialDelaySeconds: 60,
 								TimeoutSeconds:      1,
@@ -184,7 +184,7 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 	reconciled := currentState.DeepCopy()
 	reconciled.ResourceVersion = currentState.ResourceVersion
 	reconciled.Spec.Replicas = SanitizeNumberOfReplicas(cr.Spec.Instances, false)
-	reconciled.Spec.Template.Spec.Volumes = KeycloakVolumes()
+	reconciled.Spec.Template.Spec.Volumes = KeycloakVolumes(cr)
 	reconciled.Spec.Template.Spec.Containers = []v1.Container{
 		{
 			Name:  KeycloakDeploymentName,
@@ -207,7 +207,7 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 					Protocol:      "TCP",
 				},
 			},
-			VolumeMounts: KeycloakVolumeMounts(RhssoExtensionPath),
+			VolumeMounts: KeycloakVolumeMounts(cr, RhssoExtensionPath),
 			LivenessProbe: &v1.Probe{
 				InitialDelaySeconds: 60,
 				TimeoutSeconds:      1,


### PR DESCRIPTION
## JIRA ID

https://issues.redhat.com/browse/KEYCLOAK-12806

## Additional Information
Allow mouting secrets and config maps as volumes into the keycloak pod. This can be used to provide external resources like certificates and use them in Keycloak.

## Verification Steps

1. Create a secret and a configmap with some data
1. Deploy Keycloak from a CR that sets the `secrets` and `configMaps` fields:
2.1 those fields are string arrays and the names of the resources to mount are expected
3. make sure the deployment succeeds
4. open a terminal inside the keycloak pod and check that `/etc/keycloak-secrets` and `/etc/keycloak-configmaps` exists and has the expected data.

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary
