### PR TITLE
KEYCLOAK-12841: allow creating users without credentials

### DIFF
--- a/pkg/common/controller_utils.go
+++ b/pkg/common/controller_utils.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/keycloak/keycloak-operator/pkg/model"
-
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -89,24 +87,4 @@ func GetMatchingRealms(ctx context.Context, c client.Client, labelSelector *v1.L
 	}
 
 	return list, nil
-}
-
-func EnsureCredential(user *v1alpha1.KeycloakAPIUser) {
-	if len(user.Credentials) == 0 {
-		user.Credentials = []v1alpha1.KeycloakCredential{
-			{
-				Type:      "password",
-				Value:     model.RandStringRunes(10),
-				Temporary: false,
-			},
-		}
-	}
-}
-
-// Auto generate a password if the user didn't specify one
-// It will be written to the secret
-func EnsureCredentials(users []*v1alpha1.KeycloakAPIUser) {
-	for _, user := range users {
-		EnsureCredential(user)
-	}
 }

--- a/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
@@ -83,11 +83,6 @@ func (i *KeycloakRealmReconciler) getDesiredRealmState(state *common.RealmState,
 		}
 	}
 
-	// Ensure that all users have credentials, if not provided then
-	// automatically create a password. The user can later find the
-	// credentials in the output secret
-	common.EnsureCredentials(cr.Spec.Realm.Users)
-
 	if state.Realm == nil {
 		return &common.CreateRealmAction{
 			Ref: cr,

--- a/pkg/controller/keycloakrealm/keycloakrealm_reconciler_test.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_reconciler_test.go
@@ -133,7 +133,6 @@ func TestKeycloakRealmReconciler_ReconcileCredentials(t *testing.T) {
 	assert.IsType(t, &common.PingAction{}, desiredState[0])
 	assert.IsType(t, &common.CreateRealmAction{}, desiredState[1])
 	assert.IsType(t, &common.GenericCreateAction{}, desiredState[2])
-	assert.Len(t, realm.Spec.Realm.Users[0].Credentials, 1)
 }
 
 func TestKeycloakRealmReconciler_Update(t *testing.T) {

--- a/pkg/controller/keycloakuser/keycloakuser_reconciler.go
+++ b/pkg/controller/keycloakuser/keycloakuser_reconciler.go
@@ -73,9 +73,6 @@ func (i *KeycloakuserReconciler) getKeycloakUserDesiredState(state *common.UserS
 	var actions []common.ClusterAction
 
 	if state.User == nil {
-		// Make sure all new users have credentials
-		common.EnsureCredential(&cr.Spec.User)
-
 		actions = append(actions, &common.CreateUserAction{
 			Ref:   cr,
 			Realm: i.Realm.Spec.Realm.Realm,


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-12841

## Additional Information
If no credentials are provided when creating users, the operator should not assign random ones. There are legitimate use cases where users without credentials are needed.

## Verification Steps

1. Deploy Keycloak from this branch
2. Create a realm
3. Create a user in the realm
4. Check the user output secret: it should only contain a username but no password
5. Login to the admin console and check the user: in the credential section there should be no 'Disable credentials' section

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes

Note that once credentials are assigned to a user, it is not possible to remove them via the CR. Keycloak ignores an update with removed credentials.