### PR TITLE
KEYCLOAK-12766 add X509_CA_BUNDLE env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 NAMESPACE=keycloak
 PROJECT=keycloak-operator
 PKG=github.com/keycloak/keycloak-operator
-OPERATOR_SDK_VERSION=v0.10.0
+OPERATOR_SDK_VERSION=v0.12.1
 OPERATOR_SDK_DOWNLOAD_URL=https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk-$(OPERATOR_SDK_VERSION)-x86_64-linux-gnu
 MINIKUBE_DOWNLOAD_URL=https://storage.googleapis.com/minikube/releases/v1.4.0/minikube-linux-amd64
 KUBECTL_DOWNLOAD_URL=https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -143,6 +143,10 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 										},
 									},
 								},
+								{
+									Name:  "X509_CA_BUNDLE",
+									Value: "/var/run/secrets/kubernetes.io/serviceaccount/*.crt",
+								},
 							},
 							VolumeMounts: KeycloakVolumeMounts(KeycloakExtensionPath),
 							LivenessProbe: &v1.Probe{
@@ -313,6 +317,10 @@ func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.State
 							Key: AdminPasswordProperty,
 						},
 					},
+				},
+				{
+					Name:  "X509_CA_BUNDLE",
+					Value: "/var/run/secrets/kubernetes.io/serviceaccount/*.crt",
 				},
 			},
 		},

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -139,6 +139,10 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 										},
 									},
 								},
+								{
+									Name:  "X509_CA_BUNDLE",
+									Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+								},
 							},
 							VolumeMounts: KeycloakVolumeMounts(RhssoExtensionPath),
 							LivenessProbe: &v1.Probe{
@@ -304,6 +308,10 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 							Key: AdminPasswordProperty,
 						},
 					},
+				},
+				{
+					Name:  "X509_CA_BUNDLE",
+					Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
 				},
 			},
 		},


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-12766

## Additional Information
*What:*
Adding X509_CA_BUNDLE env var for Keycloak/SSO deployment.
Small fix in Makefile - operator SDK version set to same version as in go.mod

*Why:*
To fix issue on a cluster with a self signed certificate.

*How:*
This approach for a fix was discussed on a [mailing list thread](https://groups.google.com/d/topic/keycloak-dev/WCpPV6hSB6Y/discussion).

## Verification Steps
Install on a Openshift 4 cluster with self signed certificate for OpenShift API route.
Setup your cluster as an IDP in Keycloak.
Add a test app that will use Keycloak for authentication.
Test authentication with OpenShift 4 IDP - login should succeed 

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary