### PR TITLE
KEYCLOAK-12881 allow assigning federated identities

### DIFF
--- a/pkg/controller/keycloakuser/keycloakuser_reconciler.go
+++ b/pkg/controller/keycloakuser/keycloakuser_reconciler.go
@@ -94,9 +94,43 @@ func (i *KeycloakuserReconciler) getKeycloakUserDesiredState(state *common.UserS
 		// Sync the requested roles
 		actions = append(actions, i.getUserRealmRolesDesiredState(state, cr)...)
 		actions = append(actions, i.getUserClientRolesDesiredState(state, cr)...)
+
+		// Sync the federated identities
+		actions = append(actions, i.getFederatedIdentitiesDesiredState(state, cr)...)
 	}
 
 	return actions
+}
+
+func (i *KeycloakuserReconciler) getFederatedIdentitiesDesiredState(state *common.UserState, cr *v1alpha1.KeycloakUser) []common.ClusterAction {
+	var assignIdentities []common.ClusterAction
+	var removeIdentities []common.ClusterAction
+
+	for _, identity := range cr.Spec.User.FederatedIdentities {
+		// Identity requested but not assigned?
+		if !containsIdentity(state.FederatedIdentities, identity) {
+			assignIdentities = append(assignIdentities, &common.AssignFederatedIdentity{
+				UserID: state.User.ID,
+				Ref:    identity,
+				Realm:  i.Realm.Spec.Realm.Realm,
+				Msg:    fmt.Sprintf("assigning federated identity %v to user %v", identity.IdentityProvider, state.User.UserName),
+			})
+		}
+	}
+
+	for _, identity := range state.FederatedIdentities {
+		// Identity assigned but not requested?
+		if !containsIdentity(cr.Spec.User.FederatedIdentities, identity) {
+			removeIdentities = append(removeIdentities, &common.RemoveFederatedIdentity{
+				UserID: state.User.ID,
+				Ref:    identity,
+				Realm:  i.Realm.Spec.Realm.Realm,
+				Msg:    fmt.Sprintf("removing federated identity %v from user %v", identity.IdentityProvider, state.User.UserName),
+			})
+		}
+	}
+
+	return append(assignIdentities, removeIdentities...)
 }
 
 func (i *KeycloakuserReconciler) getUserRealmRolesDesiredState(state *common.UserState, cr *v1alpha1.KeycloakUser) []common.ClusterAction {
@@ -226,6 +260,17 @@ func containsRole(list []*v1alpha1.KeycloakUserRole, id string) bool {
 func containsRoleID(list []string, id string) bool {
 	for _, item := range list {
 		if item == id {
+			return true
+		}
+	}
+	return false
+}
+
+func containsIdentity(list []v1alpha1.FederatedIdentity, identity v1alpha1.FederatedIdentity) bool {
+	for _, item := range list {
+		if item.UserID == identity.UserID &&
+			item.IdentityProvider == identity.IdentityProvider &&
+			item.UserName == identity.UserName {
 			return true
 		}
 	}


### PR DESCRIPTION
## JIRA ID

https://issues.redhat.com/browse/KEYCLOAK-12881

## Additional Information

Support creating user with federated identities

## Verification Steps

1. Deploy keycloak and a realm using this branch
2. Open the admin ui for this realm and add an identity provider, e.g. openshift-v4
3. Create a user to the realm and add a federated identity, e.g.

```yaml
apiVersion: keycloak.org/v1alpha1
kind: KeycloakUser
metadata:
  name: example-realm-user
  labels:
    app: sso
spec:
  user:
    username: "realm_user"
    firstName: "John"
    lastName: "Doe"
    email: "user@example.com"
    enabled: True
    emailVerified: True
    federatedIdentities:
      - identityProvider: openshift-v4
        userId: ca407d6a-467f-11ea-9d22-0a580a80002d
        userName: realm_user
  realmSelector:
    matchLabels:
      app: sso
```

4. Open the admin UI and make sure the user has the identity assigned
5. Open the KeycloakUser CR in openshift and remove the federated identity
6. Make sure the operator reconciles the user and the identity gets removed

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary