### PR TITLE
Adding delete permission to the endpoint apiGroup

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -21,6 +21,7 @@ rules:
   - create
   - update
   - watch
+  - delete
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
Adding delte permission to the endpoint apiGroup so that Keycloak Operator does not fail when setting ownerRef while creating an external database endpoint

## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Additional Information
When enabling external database, the Operator fails with the following error message: -
```
endpoints “keycloak-postgresql” is forbidden: cannot set an ownerRef on a
    resource you can’t delete: , <nil>
```

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Enable External Database
2. Create secret keycloak-db-secret. Use DB IP Address not hostname
3. Observe that running the command kubectl get endpoints keycloak-postgresql -o yaml contains the ownerReference
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->