### PR TITLE
KEYCLOAK-12915: Add missing rights to be able to run on clusterscope

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -69,6 +69,7 @@ rules:
     resources:
       - servicemonitors
       - prometheusrules
+      - prometheusrules
     verbs:
       - list
       - get

--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -116,6 +116,8 @@ rules:
       - keycloakbackups
       - keycloakbackups/status
       - keycloakbackups/finalizers
+      - keycloakclients
+      - keycloakusers
     verbs:
       - get
       - list

--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -68,7 +68,7 @@ rules:
       - monitoring.coreos.com
     resources:
       - servicemonitors
-      - prometheusrules
+      - podmonitors
       - prometheusrules
     verbs:
       - list


### PR DESCRIPTION
@slaskawi as requested I've created a ticket. Due to lack of knowledge how I can change my existing pull requested I've decided to create a new one.

For the completeness here also the text of the ticket:

We tried to test the Keycloak-operator on cluster level. Therefore as documented within the code we changed the WATCH_NAMESPACE variable to be empty.

```
        env:
        - name: WATCH_NAMESPACE
        - name: POD_NAME
          valueFrom:
            fieldRef:
              apiVersion: v1
              fieldPath: metadata.name
```

which resulted into the following errors.

```
E0131 14:02:51.608725       1 reflector.go:125] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1.PodMonitor: podmonitors.monitoring.coreos.com is forbidden: User "system:serviceaccount:keycloak:keycloak-operator" cannot list resource "podmonitors" in API group "monitoring.coreos.com" at the cluster scope
E0131 14:02:51.609971       1 reflector.go:125] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1alpha1.KeycloakUser: keycloakusers.keycloak.org is forbidden: User "system:serviceaccount:keycloak:keycloak-operator" cannot list resource "keycloakusers" in API group "keycloak.org" at the cluster scope
E0131 14:02:52.586968       1 reflector.go:125] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to list *v1alpha1.KeycloakClient: keycloakclients.keycloak.org is forbidden: User "system:serviceaccount:keycloak:keycloak-operator" cannot list resource "keycloakclients" in API group "keycloak.org" at the cluster scope
```

Extending the ClusterRole as needed fixed that. Further after playing with the Operator I've found also out that we need also rights for podmonitors.
