### PR TITLE
Keycloak 12917: Fix PodMonitor Naming to prevent Prometheus-Operator from breaking

### DIFF
--- a/pkg/model/pod_monitor.go
+++ b/pkg/model/pod_monitor.go
@@ -12,7 +12,7 @@ import (
 func PodMonitor(cr *v1alpha1.Keycloak) *monitoringv1.PodMonitor {
 	return &monitoringv1.PodMonitor{
 		ObjectMeta: v12.ObjectMeta{
-			Name:      ApplicationName,
+			Name:      ApplicationName + "-pod",
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
 				"monitoring-key": MonitoringKey,


### PR DESCRIPTION
Hi Guys,

me again. Once I had fixed the rights for the operator [KEYCLOAK-12915] (so it was able to work with prometheus-operator) it broke the config of the prometheus operator.

Background is that it creates currently a PodMonitor as well a ServiceMonitor with the *ApplicationName* which result into a duplicate scrape job within the config since they have both the same name.

{code}
 level=error ts=2020-02-01T00:19:35.770Z caller=main.go:587 msg="Error reloading config" err="couldn't load configuration (--config.file=\"/etc/prometheus/config_out/prometheus.env.yaml\"): parsing YAML file /etc/prometheus/config_out/prometheus.env.yaml: found multiple scrape configs with job name \"keycloak/keycloak/0\""
{code}

I would suggest adding a (in future configurable?) postfix on the PodMonitor. Which I did here in the PR. This solves the issue with the duplicate scrape job name.
