### PR TITLE
KEYCLOAK-12929 external database support with uri

### DIFF
--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -189,7 +189,7 @@ func (i *ClusterState) readPostgresqlPersistentVolumeClaimCurrentState(context c
 }
 
 func (i *ClusterState) readPostgresqlServiceCurrentState(context context.Context, cr *kc.Keycloak, controllerClient client.Client) error {
-	postgresqlService := model.PostgresqlService(cr)
+	postgresqlService := model.PostgresqlService(cr, nil, false)
 	postgresqlServiceSelector := model.PostgresqlServiceSelector(cr)
 
 	err := controllerClient.Get(context, postgresqlServiceSelector, postgresqlService)
@@ -387,10 +387,10 @@ func (i *ClusterState) readProbesCurrentState(context context.Context, cr *kc.Ke
 func (i *ClusterState) readKeycloakOrRHSSODeploymentCurrentState(context context.Context, cr *kc.Keycloak, controllerClient client.Client) error {
 	isRHSSO := cr.Spec.Profile == RHSSOProfile
 
-	deployment := model.KeycloakDeployment(cr)
+	deployment := model.KeycloakDeployment(cr, nil)
 	selector := model.KeycloakDeploymentSelector(cr)
 	if isRHSSO {
-		deployment = model.RHSSODeployment(cr)
+		deployment = model.RHSSODeployment(cr, nil)
 		selector = model.RHSSODeploymentSelector(cr)
 	}
 

--- a/pkg/controller/keycloak/keycloak_migrations_test.go
+++ b/pkg/controller/keycloak/keycloak_migrations_test.go
@@ -30,7 +30,7 @@ func TestKeycloakMigrations_Test_No_Need_For_Migration_On_Missing_Deployment_In_
 	migrator := NewDefaultMigrator()
 	cr := &v1alpha1.Keycloak{}
 
-	keycloakDeployment := model.KeycloakDeployment(cr)
+	keycloakDeployment := model.KeycloakDeployment(cr, nil)
 	keycloakDeployment.Spec.Replicas = &[]int32{5}[0]
 	keycloakDeployment.Spec.Template.Spec.Containers[0].Image = "old_image" //nolint
 
@@ -56,7 +56,7 @@ func TestKeycloakMigrations_Test_Migrating_Image(t *testing.T) {
 	migrator := NewDefaultMigrator()
 	cr := &v1alpha1.Keycloak{}
 
-	keycloakDeployment := model.KeycloakDeployment(cr)
+	keycloakDeployment := model.KeycloakDeployment(cr, model.DatabaseSecret(cr))
 	keycloakDeployment.Spec.Replicas = &[]int32{5}[0]
 	keycloakDeployment.Spec.Template.Spec.Containers[0].Image = "old_image" //nolint
 
@@ -66,7 +66,7 @@ func TestKeycloakMigrations_Test_Migrating_Image(t *testing.T) {
 
 	desiredState := common.DesiredClusterState{}
 	desiredState = append(desiredState, common.GenericUpdateAction{
-		Ref: model.KeycloakDeployment(cr),
+		Ref: model.KeycloakDeployment(cr, nil),
 	})
 
 	// when
@@ -86,7 +86,7 @@ func TestKeycloakMigrations_Test_Migrating_RHSSO_Image(t *testing.T) {
 		},
 	}
 
-	keycloakDeployment := model.RHSSODeployment(cr)
+	keycloakDeployment := model.RHSSODeployment(cr, model.DatabaseSecret(cr))
 	keycloakDeployment.Spec.Replicas = &[]int32{5}[0]
 	keycloakDeployment.Spec.Template.Spec.Containers[0].Image = "old_image" //nolint
 
@@ -96,7 +96,7 @@ func TestKeycloakMigrations_Test_Migrating_RHSSO_Image(t *testing.T) {
 
 	desiredState := common.DesiredClusterState{}
 	desiredState = append(desiredState, common.GenericUpdateAction{
-		Ref: model.RHSSODeployment(cr),
+		Ref: model.RHSSODeployment(cr, model.DatabaseSecret(cr)),
 	})
 
 	// when

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -32,10 +32,10 @@ func (i *KeycloakReconciler) Reconcile(clusterState *common.ClusterState, cr *kc
 		desired = desired.AddAction(i.getDatabaseSecretDesiredState(clusterState, cr))
 		desired = desired.AddAction(i.getPostgresqlPersistentVolumeClaimDesiredState(clusterState, cr))
 		desired = desired.AddAction(i.getPostgresqlDeploymentDesiredState(clusterState, cr))
+		desired = desired.AddAction(i.getPostgresqlServiceDesiredState(clusterState, cr, false))
 	} else {
-		desired = desired.AddAction(i.getPostgresqlServiceEndpointsDesiredState(clusterState, cr))
+		i.reconcileExternalDatabase(&desired, clusterState, cr)
 	}
-	desired = desired.AddAction(i.getPostgresqlServiceDesiredState(clusterState, cr))
 
 	desired = desired.AddAction(i.getKeycloakServiceDesiredState(clusterState, cr))
 	desired = desired.AddAction(i.getKeycloakDiscoveryServiceDesiredState(clusterState, cr))
@@ -44,6 +44,24 @@ func (i *KeycloakReconciler) Reconcile(clusterState *common.ClusterState, cr *kc
 	i.reconcileExternalAccess(&desired, clusterState, cr)
 	desired = desired.AddAction(i.getPodDisruptionBudgetDesiredState(clusterState, cr))
 	return desired
+}
+
+func (i *KeycloakReconciler) reconcileExternalDatabase(desired *common.DesiredClusterState, clusterState *common.ClusterState, cr *kc.Keycloak) {
+	// If the database secret does not exist we can't continue
+	if clusterState.DatabaseSecret == nil {
+		return
+	}
+	if model.IsIP(clusterState.DatabaseSecret.Data[model.DatabaseSecretExternalAddressProperty]) {
+		// If the address of the external database is an IP address then we have to
+		// set up an endpoints object for the service to send traffic. An externalName
+		// type service won't work in this case. For more details, see https://cloud.google.com/blog/products/gcp/kubernetes-best-practices-mapping-external-services
+		desired.AddAction(i.getPostgresqlServiceEndpointsDesiredState(clusterState, cr))
+		desired.AddAction(i.getPostgresqlServiceDesiredState(clusterState, cr, false))
+	} else {
+		// If we have an URI for the external database then we can use a service of
+		// type externalName
+		desired.AddAction(i.getPostgresqlServiceDesiredState(clusterState, cr, true))
+	}
 }
 
 func (i *KeycloakReconciler) reconcileExternalAccess(desired *common.DesiredClusterState, clusterState *common.ClusterState, cr *kc.Keycloak) {
@@ -104,8 +122,8 @@ func (i *KeycloakReconciler) getPostgresqlPersistentVolumeClaimDesiredState(clus
 	}
 }
 
-func (i *KeycloakReconciler) getPostgresqlServiceDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
-	postgresqlService := model.PostgresqlService(cr)
+func (i *KeycloakReconciler) getPostgresqlServiceDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak, isExternal bool) common.ClusterAction {
+	postgresqlService := model.PostgresqlService(cr, clusterState.DatabaseSecret, isExternal)
 	if clusterState.PostgresqlService == nil {
 		return common.GenericCreateAction{
 			Ref: postgresqlService,
@@ -113,7 +131,7 @@ func (i *KeycloakReconciler) getPostgresqlServiceDesiredState(clusterState *comm
 		}
 	}
 	return common.GenericUpdateAction{
-		Ref: model.PostgresqlServiceReconciled(cr, clusterState.PostgresqlService),
+		Ref: model.PostgresqlServiceReconciled(clusterState.PostgresqlService),
 		Msg: "Update Postgresql KeycloakService",
 	}
 }
@@ -274,11 +292,11 @@ func (i *KeycloakReconciler) getDatabaseSecretDesiredState(clusterState *common.
 func (i *KeycloakReconciler) getKeycloakDeploymentOrRHSSODesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
 	isRHSSO := cr.Spec.Profile == common.RHSSOProfile
 
-	deployment := model.KeycloakDeployment(cr)
+	deployment := model.KeycloakDeployment(cr, clusterState.DatabaseSecret)
 	deploymentName := "Keycloak"
 
 	if isRHSSO {
-		deployment = model.RHSSODeployment(cr)
+		deployment = model.RHSSODeployment(cr, clusterState.DatabaseSecret)
 		deploymentName = common.RHSSOProfile
 	}
 
@@ -289,9 +307,9 @@ func (i *KeycloakReconciler) getKeycloakDeploymentOrRHSSODesiredState(clusterSta
 		}
 	}
 
-	deploymentReconciled := model.KeycloakDeploymentReconciled(cr, clusterState.KeycloakDeployment)
+	deploymentReconciled := model.KeycloakDeploymentReconciled(cr, clusterState.KeycloakDeployment, clusterState.DatabaseSecret)
 	if isRHSSO {
-		deploymentReconciled = model.RHSSODeploymentReconciled(cr, clusterState.KeycloakDeployment)
+		deploymentReconciled = model.RHSSODeploymentReconciled(cr, clusterState.KeycloakDeployment, clusterState.DatabaseSecret)
 	}
 
 	return common.GenericUpdateAction{

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -73,11 +73,11 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlService(cr), desiredState[7].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlService(cr, model.DatabaseSecret(cr), false), desiredState[7].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakProbes(cr), desiredState[10].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[11].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.KeycloakDeployment(cr, model.DatabaseSecret(cr)), desiredState[11].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakRoute(cr), desiredState[12].(common.GenericCreateAction).Ref)
 }
 
@@ -105,7 +105,7 @@ func TestKeycloakReconciler_Test_Creating_RHSSO(t *testing.T) {
 		if reflect.TypeOf(v) != reflect.TypeOf(common.GenericCreateAction{}) {
 			allCreateActions = false
 		}
-		if reflect.TypeOf(v.(common.GenericCreateAction).Ref) == reflect.TypeOf(model.RHSSODeployment(cr)) {
+		if reflect.TypeOf(v.(common.GenericCreateAction).Ref) == reflect.TypeOf(model.RHSSODeployment(cr, model.DatabaseSecret(cr))) {
 			deployment = v.(common.GenericCreateAction).Ref.(*v13.StatefulSet)
 		}
 		if reflect.TypeOf(v.(common.GenericCreateAction).Ref) == reflect.TypeOf(model.KeycloakIngress(cr)) {
@@ -115,7 +115,7 @@ func TestKeycloakReconciler_Test_Creating_RHSSO(t *testing.T) {
 	assert.True(t, allCreateActions)
 	assert.NotNil(t, deployment)
 	assert.NotNil(t, ingress)
-	assert.Equal(t, model.RHSSODeployment(cr), deployment)
+	assert.Equal(t, model.RHSSODeployment(cr, nil), deployment)
 }
 
 func TestKeycloakReconciler_Test_Updating_RHSSO(t *testing.T) {
@@ -135,11 +135,11 @@ func TestKeycloakReconciler_Test_Updating_RHSSO(t *testing.T) {
 		KeycloakGrafanaDashboard:        model.GrafanaDashboard(cr),
 		DatabaseSecret:                  model.DatabaseSecret(cr),
 		PostgresqlPersistentVolumeClaim: model.PostgresqlPersistentVolumeClaim(cr),
-		PostgresqlService:               model.PostgresqlService(cr),
+		PostgresqlService:               model.PostgresqlService(cr, model.DatabaseSecret(cr), false),
 		PostgresqlDeployment:            model.PostgresqlDeployment(cr),
 		KeycloakService:                 model.KeycloakService(cr),
 		KeycloakDiscoveryService:        model.KeycloakDiscoveryService(cr),
-		KeycloakDeployment:              model.RHSSODeployment(cr),
+		KeycloakDeployment:              model.RHSSODeployment(cr, model.DatabaseSecret(cr)),
 		KeycloakAdminSecret:             model.KeycloakAdminSecret(cr),
 		KeycloakIngress:                 model.KeycloakIngress(cr),
 		KeycloakProbes:                  model.KeycloakProbes(cr),
@@ -156,13 +156,13 @@ func TestKeycloakReconciler_Test_Updating_RHSSO(t *testing.T) {
 		if reflect.TypeOf(v) != reflect.TypeOf(common.GenericUpdateAction{}) {
 			allUpdateActions = false
 		}
-		if reflect.TypeOf(v.(common.GenericUpdateAction).Ref) == reflect.TypeOf(model.RHSSODeployment(cr)) {
+		if reflect.TypeOf(v.(common.GenericUpdateAction).Ref) == reflect.TypeOf(model.RHSSODeployment(cr, model.DatabaseSecret(cr))) {
 			deployment = v.(common.GenericUpdateAction).Ref.(*v13.StatefulSet)
 		}
 	}
 	assert.True(t, allUpdateActions)
 	assert.NotNil(t, deployment)
-	assert.Equal(t, model.RHSSODeployment(cr), deployment)
+	assert.Equal(t, model.RHSSODeployment(cr, model.DatabaseSecret(cr)), deployment)
 }
 
 func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
@@ -178,11 +178,11 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 		KeycloakGrafanaDashboard:        model.GrafanaDashboard(cr),
 		DatabaseSecret:                  model.DatabaseSecret(cr),
 		PostgresqlPersistentVolumeClaim: model.PostgresqlPersistentVolumeClaim(cr),
-		PostgresqlService:               model.PostgresqlService(cr),
+		PostgresqlService:               model.PostgresqlService(cr, model.DatabaseSecret(cr), false),
 		PostgresqlDeployment:            model.PostgresqlDeployment(cr),
 		KeycloakService:                 model.KeycloakService(cr),
 		KeycloakDiscoveryService:        model.KeycloakDiscoveryService(cr),
-		KeycloakDeployment:              model.KeycloakDeployment(cr),
+		KeycloakDeployment:              model.KeycloakDeployment(cr, model.DatabaseSecret(cr)),
 		KeycloakAdminSecret:             model.KeycloakAdminSecret(cr),
 		KeycloakRoute:                   model.KeycloakRoute(cr),
 		KeycloakProbes:                  model.KeycloakProbes(cr),
@@ -234,10 +234,10 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.PostgresqlService(cr), desiredState[7].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PostgresqlService(cr, model.DatabaseSecret(cr), false), desiredState[7].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[10].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.KeycloakDeployment(cr, model.DatabaseSecret(cr)), desiredState[10].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.KeycloakRoute(cr), desiredState[11].(common.GenericUpdateAction).Ref)
 }
 
@@ -272,6 +272,7 @@ func TestKeycloakReconciler_Test_Creating_All_With_External_Database(t *testing.
 	cr.Spec.ExternalDatabase.Enabled = true
 
 	currentState := common.NewClusterState()
+	currentState.DatabaseSecret = model.DatabaseSecret(cr)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -285,11 +286,11 @@ func TestKeycloakReconciler_Test_Creating_All_With_External_Database(t *testing.
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[4])
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[5])
 	assert.IsType(t, model.DatabaseSecret(cr), desiredState[0].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlService(cr), desiredState[1].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlService(cr, model.DatabaseSecret(cr), false), desiredState[1].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakService(cr), desiredState[2].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[3].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakProbes(cr), desiredState[4].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.KeycloakDeployment(cr), desiredState[5].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.KeycloakDeployment(cr, model.DatabaseSecret(cr)), desiredState[5].(common.GenericCreateAction).Ref)
 }
 
 func TestKeycloakReconciler_Test_Updating_External_Database(t *testing.T) {
@@ -321,6 +322,41 @@ func TestKeycloakReconciler_Test_Updating_External_Database(t *testing.T) {
 	}
 	assert.NotNil(t, endpoints)
 	assert.Equal(t, model.PostgresqlServiceEndpointsReconciled(cr, currentState.PostgresqlServiceEndpoints, currentState.DatabaseSecret), endpoints)
+}
+
+func TestKeycloakReconciler_Test_Updating_External_Database_URI(t *testing.T) {
+	// given
+	cr := &v1alpha1.Keycloak{}
+	cr.Spec.ExternalDatabase.Enabled = true
+
+	currentState := common.NewClusterState()
+	currentState.PostgresqlServiceEndpoints = model.PostgresqlServiceEndpoints(cr)
+	currentState.DatabaseSecret = model.DatabaseSecret(cr)
+	// This conversion is done my K8s. In the tests, we need to fake it.
+	currentState.DatabaseSecret.Data = map[string][]byte{
+		model.DatabaseSecretExternalAddressProperty: []byte("host.example.database.location"),
+		model.DatabaseSecretExternalPortProperty:    []byte("5432"),
+	}
+
+	// when
+	reconciler := NewKeycloakReconciler()
+	desiredState := reconciler.Reconcile(currentState, cr)
+
+	// then
+	var service *v1.Service
+	for _, v := range desiredState {
+		if reflect.TypeOf(v) == reflect.TypeOf(common.GenericCreateAction{}) {
+			if reflect.TypeOf(v.(common.GenericCreateAction).Ref) == reflect.TypeOf(model.PostgresqlService(cr, currentState.DatabaseSecret, true)) {
+				s := v.(common.GenericCreateAction).Ref.(*v1.Service)
+				if s.Name == model.PostgresqlServiceName {
+					service = s
+				}
+			}
+		}
+	}
+	assert.NotNil(t, service)
+	assert.Equal(t, service.Spec.Type, v1.ServiceTypeExternalName)
+	assert.Equal(t, service.Spec.ExternalName, string(currentState.DatabaseSecret.Data[model.DatabaseSecretExternalAddressProperty]))
 }
 
 func TestKeycloakReconciler_Test_Recreate_Credentials_When_Missig(t *testing.T) {
@@ -387,4 +423,10 @@ func TestKeycloakReconciler_Test_Should_Update_PDB(t *testing.T) {
 	assert.Equal(t, len(desiredState), 10)
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[9])
 	assert.IsType(t, model.PodDisruptionBudget(cr), desiredState[9].(common.GenericUpdateAction).Ref)
+}
+
+func TestIsIP(t *testing.T) {
+	assert.True(t, model.IsIP([]byte("54.154.171.84")))
+	assert.False(t, model.IsIP([]byte("this.is.a.hostname")))
+	assert.False(t, model.IsIP([]byte("http://www.database.url")))
 }

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -35,6 +35,7 @@ const (
 	DatabaseSecretExternalAddressProperty = "POSTGRES_EXTERNAL_ADDRESS" // nolint
 	DatabaseSecretExternalPortProperty    = "POSTGRES_EXTERNAL_PORT"    // nolint
 	KeycloakServicePort                   = 8443
+	PostgresDefaultPort                   = 5432
 	AdminUsernameProperty                 = "ADMIN_USERNAME"        // nolint
 	AdminPasswordProperty                 = "ADMIN_PASSWORD"        // nolint
 	ServingCertSecretName                 = "sso-x509-https-secret" // nolint

--- a/pkg/model/postgresql_service.go
+++ b/pkg/model/postgresql_service.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"fmt"
+
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -8,7 +10,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PostgresqlService(cr *v1alpha1.Keycloak) *v1.Service {
+func getSpec(dbSecret *v1.Secret, serviceTypeExternal bool) v1.ServiceSpec {
+	spec := v1.ServiceSpec{}
+
+	if serviceTypeExternal {
+		spec.Type = v1.ServiceTypeExternalName
+		spec.Selector = nil
+		spec.ExternalName = GetExternalDatabaseHost(dbSecret)
+	} else {
+		spec.Type = v1.ServiceTypeClusterIP
+		spec.Selector = map[string]string{
+			"app":       ApplicationName,
+			"component": PostgresqlDeploymentComponent,
+		}
+	}
+
+	spec.Ports = []v1.ServicePort{
+		{
+			Port:       GetExternalDatabasePort(dbSecret),
+			TargetPort: intstr.Parse(fmt.Sprintf("%d", GetExternalDatabasePort(dbSecret))),
+		},
+	}
+
+	return spec
+}
+
+func PostgresqlService(cr *v1alpha1.Keycloak, dbSecret *v1.Secret, serviceTypeExternal bool) *v1.Service {
 	return &v1.Service{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      PostgresqlServiceName,
@@ -17,18 +44,7 @@ func PostgresqlService(cr *v1alpha1.Keycloak) *v1.Service {
 				"app": ApplicationName,
 			},
 		},
-		Spec: v1.ServiceSpec{
-			Selector: map[string]string{
-				"app":       ApplicationName,
-				"component": PostgresqlDeploymentComponent,
-			},
-			Ports: []v1.ServicePort{
-				{
-					Port:       5432,
-					TargetPort: intstr.Parse("5432"),
-				},
-			},
-		},
+		Spec: getSpec(dbSecret, serviceTypeExternal),
 	}
 }
 
@@ -39,7 +55,7 @@ func PostgresqlServiceSelector(cr *v1alpha1.Keycloak) client.ObjectKey {
 	}
 }
 
-func PostgresqlServiceReconciled(cr *v1alpha1.Keycloak, currentState *v1.Service) *v1.Service {
+func PostgresqlServiceReconciled(currentState *v1.Service) *v1.Service {
 	reconciled := currentState.DeepCopy()
 	reconciled.Spec.Ports = []v1.ServicePort{
 		{

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -11,7 +12,98 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
+func getRHSSOEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
+	return []v1.EnvVar{
+		// Database settings
+		{
+			Name:  "DB_SERVICE_PREFIX_MAPPING",
+			Value: PostgresqlServiceName + "=DB",
+		},
+		{
+			Name:  "TX_DATABASE_PREFIX_MAPPING",
+			Value: PostgresqlServiceName + "=DB",
+		},
+		{
+			Name:  "DB_JNDI",
+			Value: "java:jboss/datasources/KeycloakDS",
+		},
+		{
+			Name:  "DB_SCHEMA",
+			Value: "public",
+		},
+		{
+			Name: "DB_USERNAME",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: DatabaseSecretName,
+					},
+					Key: DatabaseSecretUsernameProperty,
+				},
+			},
+		},
+		{
+			Name: "DB_PASSWORD",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: DatabaseSecretName,
+					},
+					Key: DatabaseSecretPasswordProperty,
+				},
+			},
+		},
+		{
+			Name:  "DB_DATABASE",
+			Value: GetExternalDatabaseName(dbSecret),
+		},
+		// Discovery settings
+		{
+			Name:  "JGROUPS_PING_PROTOCOL",
+			Value: "dns.DNS_PING",
+		},
+		{
+			Name:  "OPENSHIFT_DNS_PING_SERVICE_NAME",
+			Value: KeycloakDiscoveryServiceName + "." + cr.Namespace + ".svc.cluster.local",
+		},
+		{
+			Name: "SSO_ADMIN_USERNAME",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "credential-" + cr.Name,
+					},
+					Key: AdminUsernameProperty,
+				},
+			},
+		},
+		{
+			Name: "SSO_ADMIN_PASSWORD",
+			ValueFrom: &v1.EnvVarSource{
+				SecretKeyRef: &v1.SecretKeySelector{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: "credential-" + cr.Name,
+					},
+					Key: AdminPasswordProperty,
+				},
+			},
+		},
+		{
+			Name:  GetServiceEnvVar("SERVICE_HOST"),
+			Value: PostgresqlServiceName + "." + cr.Namespace + ".svc.cluster.local",
+		},
+		{
+			Name:  GetServiceEnvVar("SERVICE_PORT"),
+			Value: fmt.Sprintf("%v", GetExternalDatabasePort(dbSecret)),
+		},
+		{
+			Name:  "X509_CA_BUNDLE",
+			Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+		},
+	}
+}
+
+func RHSSODeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.StatefulSet {
 	return &v13.StatefulSet{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      KeycloakDeploymentName,
@@ -63,89 +155,10 @@ func RHSSODeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 									Protocol:      "TCP",
 								},
 							},
-							Env: []v1.EnvVar{
-								// Database settings
-								{
-									Name:  "DB_SERVICE_PREFIX_MAPPING",
-									Value: PostgresqlServiceName + "=DB",
-								},
-								{
-									Name:  "TX_DATABASE_PREFIX_MAPPING",
-									Value: PostgresqlServiceName + "=DB",
-								},
-								{
-									Name:  "DB_JNDI",
-									Value: "java:jboss/datasources/KeycloakDS",
-								},
-								{
-									Name:  "DB_SCHEMA",
-									Value: "public",
-								},
-								{
-									Name: "DB_USERNAME",
-									ValueFrom: &v1.EnvVarSource{
-										SecretKeyRef: &v1.SecretKeySelector{
-											LocalObjectReference: v1.LocalObjectReference{
-												Name: DatabaseSecretName,
-											},
-											Key: DatabaseSecretUsernameProperty,
-										},
-									},
-								},
-								{
-									Name: "DB_PASSWORD",
-									ValueFrom: &v1.EnvVarSource{
-										SecretKeyRef: &v1.SecretKeySelector{
-											LocalObjectReference: v1.LocalObjectReference{
-												Name: DatabaseSecretName,
-											},
-											Key: DatabaseSecretPasswordProperty,
-										},
-									},
-								},
-								{
-									Name:  "DB_DATABASE",
-									Value: PostgresqlDatabase,
-								},
-								// Discovery settings
-								{
-									Name:  "JGROUPS_PING_PROTOCOL",
-									Value: "dns.DNS_PING",
-								},
-								{
-									Name:  "OPENSHIFT_DNS_PING_SERVICE_NAME",
-									Value: KeycloakDiscoveryServiceName + "." + cr.Namespace + ".svc.cluster.local",
-								},
-								{
-									Name: "SSO_ADMIN_USERNAME",
-									ValueFrom: &v1.EnvVarSource{
-										SecretKeyRef: &v1.SecretKeySelector{
-											LocalObjectReference: v1.LocalObjectReference{
-												Name: "credential-" + cr.Name,
-											},
-											Key: AdminUsernameProperty,
-										},
-									},
-								},
-								{
-									Name: "SSO_ADMIN_PASSWORD",
-									ValueFrom: &v1.EnvVarSource{
-										SecretKeyRef: &v1.SecretKeySelector{
-											LocalObjectReference: v1.LocalObjectReference{
-												Name: "credential-" + cr.Name,
-											},
-											Key: AdminPasswordProperty,
-										},
-									},
-								},
-								{
-									Name:  "X509_CA_BUNDLE",
-									Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-								},
-							},
-							VolumeMounts:   KeycloakVolumeMounts(RhssoExtensionPath),
 							LivenessProbe:  livenessProbe(),
 							ReadinessProbe: readinessProbe(),
+							Env:            getRHSSOEnv(cr, dbSecret),
+							VolumeMounts:   KeycloakVolumeMounts(RhssoExtensionPath),
 						},
 					},
 				},
@@ -161,7 +174,7 @@ func RHSSODeploymentSelector(cr *v1alpha1.Keycloak) client.ObjectKey {
 	}
 }
 
-func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.StatefulSet) *v13.StatefulSet {
+func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.StatefulSet, dbSecret *v1.Secret) *v13.StatefulSet {
 	currentImage := GetCurrentKeycloakImage(currentState)
 
 	reconciled := currentState.DeepCopy()
@@ -193,86 +206,7 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 			VolumeMounts:   KeycloakVolumeMounts(RhssoExtensionPath),
 			LivenessProbe:  livenessProbe(),
 			ReadinessProbe: readinessProbe(),
-			Env: []v1.EnvVar{
-				// Database settings
-				{
-					Name:  "DB_SERVICE_PREFIX_MAPPING",
-					Value: PostgresqlServiceName + "=DB",
-				},
-				{
-					Name:  "TX_DATABASE_PREFIX_MAPPING",
-					Value: PostgresqlServiceName + "=DB",
-				},
-				{
-					Name:  "DB_JNDI",
-					Value: "java:jboss/datasources/KeycloakDS",
-				},
-				{
-					Name:  "DB_SCHEMA",
-					Value: "public",
-				},
-				{
-					Name: "DB_USERNAME",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: DatabaseSecretName,
-							},
-							Key: DatabaseSecretUsernameProperty,
-						},
-					},
-				},
-				{
-					Name: "DB_PASSWORD",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: DatabaseSecretName,
-							},
-							Key: DatabaseSecretPasswordProperty,
-						},
-					},
-				},
-				{
-					Name:  "DB_DATABASE",
-					Value: PostgresqlDatabase,
-				},
-				// Discovery settings
-				{
-					Name:  "JGROUPS_PING_PROTOCOL",
-					Value: "dns.DNS_PING",
-				},
-				{
-					Name:  "OPENSHIFT_DNS_PING_SERVICE_NAME",
-					Value: KeycloakDiscoveryServiceName + "." + cr.Namespace + ".svc.cluster.local",
-				},
-				{
-					Name: "SSO_ADMIN_USERNAME",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: "credential-" + cr.Name,
-							},
-							Key: AdminUsernameProperty,
-						},
-					},
-				},
-				{
-					Name: "SSO_ADMIN_PASSWORD",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: "credential-" + cr.Name,
-							},
-							Key: AdminPasswordProperty,
-						},
-					},
-				},
-				{
-					Name:  "X509_CA_BUNDLE",
-					Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
-				},
-			},
+			Env:            getRHSSOEnv(cr, dbSecret),
 		},
 	}
 	reconciled.Spec.Template.Spec.InitContainers = KeycloakExtensionsInitContainers(cr)

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -4,7 +4,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"net"
+	"strconv"
 	"strings"
+
+	v1 "k8s.io/api/core/v1"
 
 	v13 "k8s.io/api/apps/v1"
 )
@@ -136,4 +140,35 @@ func GetImageRepoAndVersion(image string) (string, string, string, string) {
 	}
 
 	return imageRepo, imageMajor, imageMinor, imagePatch
+}
+
+func IsIP(host []byte) bool {
+	return net.ParseIP(string(host)) != nil
+}
+
+func GetExternalDatabaseHost(secret *v1.Secret) string {
+	host := secret.Data[DatabaseSecretExternalAddressProperty]
+	return string(host)
+}
+
+func GetExternalDatabaseName(secret *v1.Secret) string {
+	if secret == nil {
+		return PostgresqlDatabase
+	}
+
+	name := secret.Data[DatabaseSecretDatabaseProperty]
+	return string(name)
+}
+
+func GetExternalDatabasePort(secret *v1.Secret) int32 {
+	if secret == nil {
+		return PostgresDefaultPort
+	}
+
+	port := secret.Data[DatabaseSecretExternalPortProperty]
+	parsed, err := strconv.Atoi(string(port))
+	if err != nil {
+		return PostgresDefaultPort
+	}
+	return int32(parsed)
 }

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -61,3 +61,8 @@ func TestUtil_Test_GetImageRepoAndVersion_With_No_Image(t *testing.T) {
 	assert.Equal(t, imageMinor, "")
 	assert.Equal(t, imagePatch, "")
 }
+
+func TestUtil_Test_GetServiceEnvVar(t *testing.T) {
+	assert.Equal(t, GetServiceEnvVar("SERVICE_HOST"), "KEYCLOAK_POSTGRESQL_SERVICE_HOST")
+	assert.Equal(t, GetServiceEnvVar("SERVICE_PORT"), "KEYCLOAK_POSTGRESQL_SERVICE_PORT")
+}


### PR DESCRIPTION
## JIRA ID

https://issues.redhat.com/browse/KEYCLOAK-12929

ping @davidffrench 

## Additional Information

The Keycloak Operator allows connecting to external (outside of the cluster) databases by providing a pre-populated database secret. This only worked when specifying the IP Address of the external database. This is a problem because the IP address can change. We want to support both, IP and hostname.

Unfortunately IP adresses and hostnames have to be treated in different ways: Hostnames are supported by externalName type services. But this type of service does not support IP addresses and so we have to rely on default ClusterIP type services and an Endpoints object to support that use case. This PR checks if the pre-existing database secret contains an IP or a hostname and chooses the reconciliation strategy accordingly.

## Verification Steps

A number of scenarios have to be verified. For every scenario, make sure that the deployment succeeds and that there are no errors in the log. Feel free to ask me for the connection details / db secret of an external database if you need one.

1. Deploy Keycloak without an external database.
2. Deploy Keycloak with an external database using an IP address
3. Deploy Keycloak with an external database using a hostname
4. Deploy RHSSO without an external database
5. Deploy RHSSO with an external database using an IP address
6. Deploy RHSSO with an external database using a hostname

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary