### PR TITLE
KEYCLOAK-12787: Fix external Database Support

### DIFF
--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -95,9 +95,16 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 										},
 									},
 								},
-								{
-									Name:  "DB_DATABASE",
-									Value: PostgresqlDatabase,
+                {
+									Name: "DB_DATABASE",
+									ValueFrom: &v1.EnvVarSource{
+										SecretKeyRef: &v1.SecretKeySelector{
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: DatabaseSecretName,
+											},
+											Key: DatabaseSecretDatabaseProperty,
+										},
+									},
 								},
 								// Discovery settings
 								{

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -273,10 +273,17 @@ func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.State
 						},
 					},
 				},
-				{
-					Name:  "DB_DATABASE",
-					Value: PostgresqlDatabase,
-				},
+        {
+          Name: "DB_DATABASE",
+          ValueFrom: &v1.EnvVarSource{
+            SecretKeyRef: &v1.SecretKeySelector{
+              LocalObjectReference: v1.LocalObjectReference{
+                Name: DatabaseSecretName,
+              },
+              Key: DatabaseSecretDatabaseProperty,
+            },
+          },
+        },
 				// Discovery settings
 				{
 					Name:  "NAMESPACE",

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -95,7 +95,7 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak) *v13.StatefulSet {
 										},
 									},
 								},
-                {
+								{
 									Name: "DB_DATABASE",
 									ValueFrom: &v1.EnvVarSource{
 										SecretKeyRef: &v1.SecretKeySelector{
@@ -273,17 +273,17 @@ func KeycloakDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.State
 						},
 					},
 				},
-        {
-          Name: "DB_DATABASE",
-          ValueFrom: &v1.EnvVarSource{
-            SecretKeyRef: &v1.SecretKeySelector{
-              LocalObjectReference: v1.LocalObjectReference{
-                Name: DatabaseSecretName,
-              },
-              Key: DatabaseSecretDatabaseProperty,
-            },
-          },
-        },
+				{
+					Name: "DB_DATABASE",
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: DatabaseSecretName,
+							},
+							Key: DatabaseSecretDatabaseProperty,
+						},
+					},
+				},
 				// Discovery settings
 				{
 					Name:  "NAMESPACE",


### PR DESCRIPTION
This fixes that the Database name wasn't taken from the Secret which resulted in a non working setup.