### PR TITLE
KEYCLOAK-13008: Set the ClientSecret to be written as CLIENT_SECRET

### DIFF
--- a/pkg/common/client_state.go
+++ b/pkg/common/client_state.go
@@ -35,6 +35,12 @@ func (i *ClientState) Read(context context.Context, cr *kc.KeycloakClient, realm
 		return nil
 	}
 
+	clientSecret, err := realmClient.GetClientSecret(cr.Spec.Client.ID, i.Realm.Spec.Realm.Realm)
+	if err != nil {
+		return err
+	}
+	cr.Spec.Client.Secret = clientSecret
+
 	err = i.readClientSecret(context, cr, i.Client, controllerClient)
 	if err != nil {
 		return err


### PR DESCRIPTION
Hi guys,

whenever a KeycloakClient is added with:

```
clientAuthenticatorType: client-secret
```

a secret is created with 

```
CLIENT_ID
CLIENT_SECRET
```

But unfortunately the CLIENT_SECRET is always empty and therefore can't be used the way its meant.

Thats fixed within this PR.

Offtopic: Its a pain to create JIRA Ticket ... then Github-Issue .. mark all things with the JIRA-Ticket...



To check it you can adjust:
```
---
  apiVersion: keycloak.org/v1alpha1
  kind: KeycloakClient
  metadata:
    finalizers:
    - client.cleanup
    generation: 2
    name: example-name
    namespace: example-ns-name
  spec:
    client:
      bearerOnly: false
      clientAuthenticatorType: client-secret
      clientId: pay
      defaultClientScopes:
      - some-scopeshere1
      - some-scopeshere2
      - some-scopeshere3
      description: The nice description
      id: exampl-example
      protocol: openid-connect
      publicClient: false
      rootUrl: ${authBaseUrl}
      serviceAccountsEnabled: true
    realmSelector:
      matchLabels:
        iam.example.cloud/keycloak-app: example-iam
```