### PR TITLE
[KEYCLOAK-13090] Add support for adding extra Environment Variables

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -68,6 +68,12 @@ spec:
                     pointing to Keycloak.
                   type: boolean
               type: object
+            extraEnv:
+              additionalProperties:
+                type: string
+              description: Enables to pass extra Environment variables to the keycloak
+                instance
+              type: object
             instances:
               description: Number of Keycloak instances in HA mode. Default is 1.
               type: integer

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -18,6 +18,9 @@ type KeycloakSpec struct {
 	// Controls external Ingress/Route settings.
 	// +optional
 	ExternalAccess KeycloakExternalAccess `json:"externalAccess,omitempty"`
+	// Enables to pass extra Environment variables to the keycloak instance
+	// +optional
+	ExtraEnv map[string]string `json:"extraEnv,omitempty"`
 	// Controls external database settings.
 	// Using an external database requires providing a secret containing credentials
 	// as well as connection details. Here's an example of such secret:

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -798,6 +798,13 @@ func (in *KeycloakSpec) DeepCopyInto(out *KeycloakSpec) {
 		copy(*out, *in)
 	}
 	out.ExternalAccess = in.ExternalAccess
+	if in.ExtraEnv != nil {
+		in, out := &in.ExtraEnv, &out.ExtraEnv
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	out.ExternalDatabase = in.ExternalDatabase
 	out.PodDisruptionBudget = in.PodDisruptionBudget
 	return

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
@@ -558,6 +558,21 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakSpec(ref common.ReferenceCallback
 							Ref:         ref("github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1.KeycloakExternalAccess"),
 						},
 					},
+					"extraEnv": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enables to pass extra Environment variables to the keycloak instance",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Allows: true,
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
 					"externalDatabase": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret:\n\n    apiVersion: v1\n    kind: Secret\n    metadata:\n        name: keycloak-db-secret\n        namespace: keycloak\n    stringData:\n        POSTGRES_DATABASE: <Database Name>\n        POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>\n        POSTGRES_EXTERNAL_PORT: <External Database Port>\n        # Strongly recommended to use <'Keycloak CR Name'-postgresql>\n        POSTGRES_HOST: <Database Service Name>\n        POSTGRES_PASSWORD: <Database Password>\n        # Required for AWS Backup functionality\n        POSTGRES_SUPERUSER: true\n        POSTGRES_USERNAME: <Database Username>\n     type: Opaque\n\nBoth POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:\n      <Custom Resource Name>-db-secret\n\nFor more information, please refer to the Operator documentation.",

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -27,7 +27,7 @@ func GetServiceEnvVar(suffix string) string {
 }
 
 func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
-	return []v1.EnvVar{
+	defaultEnv := []v1.EnvVar{
 		// Database settings
 		{
 			Name:  "DB_VENDOR",
@@ -124,6 +124,17 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 			Value: "/var/run/secrets/kubernetes.io/serviceaccount/*.crt",
 		},
 	}
+
+	if len(cr.Spec.ExtraEnv) > 0 {
+		for k, v := range cr.Spec.ExtraEnv {
+			defaultEnv = append(defaultEnv, v1.EnvVar{
+				Name: k,
+				Value: v,
+			})
+		}
+	}
+
+	return defaultEnv
 }
 
 func KeycloakDeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.StatefulSet {

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -128,7 +128,7 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 	if len(cr.Spec.ExtraEnv) > 0 {
 		for k, v := range cr.Spec.ExtraEnv {
 			defaultEnv = append(defaultEnv, v1.EnvVar{
-				Name: k,
+				Name:  k,
 				Value: v,
 			})
 		}


### PR DESCRIPTION
Hi Guys,

the follow up PR will contain changes to be able to define custom Environment-Variables within the CRD.

For example sometimes you need to pass these things:

```
...
- name: PROXY_ADDRESS_FORWARDING
   value: "true"
- name: WILDFLY_LOGLEVEL
   value: DEBUG
- name: KEYCLOAK_LOGLEVEL
   value: DEBUG
- name: JDBC_PARAMS
   value: "?prepareThreshold=0&autoCommit=false"
...
```

 and even more which is not possible yet. 