### PR TITLE
KEYCLOAK-13158 Sanitize uppercase letters from resource name

### DIFF
--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"unicode"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -63,9 +64,9 @@ func SanitizeResourceName(name string) string {
 			continue
 		}
 
-		// Uppercase letters
+		// Uppercase letters are transformed to lowercase
 		if ascii >= 65 && ascii <= 90 {
-			sb.WriteRune(char)
+			sb.WriteRune(unicode.ToLower(char))
 			continue
 		}
 

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -66,3 +66,17 @@ func TestUtil_Test_GetServiceEnvVar(t *testing.T) {
 	assert.Equal(t, GetServiceEnvVar("SERVICE_HOST"), "KEYCLOAK_POSTGRESQL_SERVICE_HOST")
 	assert.Equal(t, GetServiceEnvVar("SERVICE_PORT"), "KEYCLOAK_POSTGRESQL_SERVICE_PORT")
 }
+
+func TestUtil_SanitizeResourceName(t *testing.T) {
+	expected := map[string]string{
+		// Allowed characters
+		"test123-_.": "test123--.",
+		// Mixed of allowed characters and disallowed characters
+		"testTEST[(/%^&*,)]123-_.": "testtest123--.",
+	}
+
+	for input, output := range expected {
+		actual := SanitizeResourceName(input)
+		assert.Equal(t, output, actual)
+	}
+}


### PR DESCRIPTION
The `SanitizeResourceName` function is used to create valid names for `Secret` resources for each `KeycloakUser`. This function doesn't sanitize uppercase letters (not allowed by Kubernetes), therefore if a user has an uppercase letter in their name, the secret will fail to be created:

```yaml
status:
  message: >-
    Secret "credential-openshift-TEST-redhat-rhmi-rhsso" is invalid:
    metadata.name: Invalid value:
    "credential-openshift-TEST-redhat-rhmi-rhsso": a DNS-1123 subdomain
    must consist of lower case alphanumeric characters, '-' or '.', and must
    start and end with an alphanumeric character (e.g. 'example.com', regex used
    for validation is
    '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
  phase: failing

```

These changes modify the `SanitizeResourceName` function to transform any uppercase characters into lowercase

## JIRA ID
[KEYCLOAK-13158](https://issues.redhat.com/browse/KEYCLOAK-13158)
This is also tracked in the Integreatly board: [INTLY-5811](https://issues.redhat.com/browse/INTLY-5811)

## Additional Information
Kubernetes documentation on resource names:
> https://kubernetes.io/docs/concepts/overview/working-with-objects/names/

## Verification Steps

1. Create a `KeycloakUser` resource with an uppercase letter in the `.spec.user.username` field
2. Wait for next reconcile
3. Check that the credentials secret for the user is created successfully with the user name transformed to lowercase

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary