### PR TITLE
KEYCLOAK-13159 Add `patch` verb to "" apiGroup

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -18,6 +18,7 @@ rules:
       - list
       - get
       - create
+      - patch
       - update
       - watch
       - delete

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -19,6 +19,7 @@ rules:
   - list
   - get
   - create
+  - patch
   - update
   - watch
   - delete


### PR DESCRIPTION
The `k8s/client-go` library logic attempts to update an event instead of creating it when it already
exists. However, the operator doesn't have permissions to patch events, so it will fail and
show a "Server rejected event" error log.

Add the `patch` verb to the `""` apiGroup in `deploy/role.yaml` in order to allow the operator
to perform the update.

## JIRA ID
[KEYCLOAK-13159](https://issues.redhat.com/browse/KEYCLOAK-13159)
Also tracked in the Integreatly board [INTLY-5812](https://issues.redhat.com/browse/INTLY-5812)

## Additional Information
* The logic in `k8s/client-go` for deciding when to patch events is based on the `Event.Count` field [1]
* The `operator-sdk` CLI already includes the `patch` verb in the scaffolding for the `role.yaml` file [2]

[1. `k8s/client-go` GitHub repository](https://github.com/kubernetes/client-go/blob/06eb1244587a17d4994ff9de4ce93756a2f16f0b/tools/record/event.go#L189)
[2. `operator-sdk` GitHub repository](https://github.com/operator-framework/operator-sdk/blob/master/internal/scaffold/role.go#L188) 

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary
