### PR TITLE
PR for KEYCLOAK-13335

### DIFF
--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -75,7 +75,7 @@ type KeycloakAPIClient struct {
 	ImplicitFlowEnabled bool `json:"implicitFlowEnabled,omitempty"`
 	// True if Direct Grant is enabled.
 	// +optional
-	DirectAccessGrantsEnabled bool `json:"directAccessGrantsEnabled,omitempty"`
+	DirectAccessGrantsEnabled bool `json:"directAccessGrantsEnabled"`
 	// True if Service Accounts are enabled.
 	// +optional
 	ServiceAccountsEnabled bool `json:"serviceAccountsEnabled,omitempty"`

--- a/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
+++ b/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
@@ -1,6 +1,8 @@
 package keycloakclient
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,7 +14,7 @@ import (
 	v13 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestKeycloakBackupReconciler_Test_Creating_Client(t *testing.T) {
+func TestKeycloakClientReconciler_Test_Creating_Client(t *testing.T) {
 	// given
 	keycloakCr := v1alpha1.Keycloak{}
 	cr := &v1alpha1.KeycloakClient{
@@ -52,7 +54,7 @@ func TestKeycloakBackupReconciler_Test_Creating_Client(t *testing.T) {
 	assert.IsType(t, model.ClientSecret(cr), desiredState[2].(common.GenericCreateAction).Ref)
 }
 
-func TestKeycloakBackupReconciler_Test_Delete_Client(t *testing.T) {
+func TestKeycloakClientReconciler_Test_Delete_Client(t *testing.T) {
 	// given
 	keycloakCr := v1alpha1.Keycloak{}
 	cr := &v1alpha1.KeycloakClient{
@@ -93,7 +95,7 @@ func TestKeycloakBackupReconciler_Test_Delete_Client(t *testing.T) {
 	assert.IsType(t, common.DeleteClientAction{}, desiredState[1])
 }
 
-func TestKeycloakBackupReconciler_Test_Update_Client(t *testing.T) {
+func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 	// given
 	keycloakCr := v1alpha1.Keycloak{}
 	cr := &v1alpha1.KeycloakClient{
@@ -134,4 +136,32 @@ func TestKeycloakBackupReconciler_Test_Update_Client(t *testing.T) {
 	assert.Equal(t, "test", desiredState[1].(common.UpdateClientAction).Realm)
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[2])
 	assert.IsType(t, model.ClientSecretReconciled(cr, currentState.ClientSecret), desiredState[2].(common.GenericUpdateAction).Ref)
+}
+
+func TestKeycloakClientReconciler_Test_Marshal_Client_directAccessGrantsEnabled(t *testing.T) {
+	// given
+	cr := &v1alpha1.KeycloakClient{
+		ObjectMeta: v13.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+		Spec: v1alpha1.KeycloakClientSpec{
+			RealmSelector: &v13.LabelSelector{
+				MatchLabels: map[string]string{"application": "sso"},
+			},
+			Client: &v1alpha1.KeycloakAPIClient{
+				ClientID:                  "test",
+				Secret:                    "test",
+				DirectAccessGrantsEnabled: false,
+			},
+		},
+	}
+
+	// when
+	b, err := json.Marshal(cr)
+	s := string(b)
+
+	// then
+	assert.Nil(t, err, "Client couldn't be marshalled")
+	assert.True(t, strings.Contains(s, "\"directAccessGrantsEnabled\":false"), "Element directAccessGrantsEnabled should not be omitted if false, as keycloaks default is true")
 }


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-13335
https://issues.redhat.com/browse/KEYCLOAK-13335

## Additional Information
Setting directAccessGrantsEnabled in the crd
apiVersion: keycloak.org/v1alpha1
kind: KeycloakClient

to false has no effect in keycloak.
The Gui show that "Direct Access Grants Enabled" is on.

The reason for that is that the file
keycloak-operator/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go

has set the property like that:
DirectAccessGrantsEnabled bool `json:"directAccessGrantsEnabled,omitempty"`

If DirectAccessGrantsEnabled is false, then the value is omitted when the client is created via the keycloak api. The keycloak-default value if the value is not specified is true.

## Verification Steps
1. Create CRD with directAccessGrantsEnabled: False
```
apiVersion: keycloak.org/v1alpha1
kind: KeycloakClient
metadata:
  name: tcm-angular-frontend
  labels:
    app: sso
spec:
  realmSelector:
    matchLabels:
      app: sso
  client:
    clientId: tcm-angular-frontend
    secret: client-secret1
    clientAuthenticatorType: client-secret
    protocol: openid-connect
    publicClient: True
    directAccessGrantsEnabled: False
    standardFlowEnabled: True
    implicitFlowEnabled: False
    serviceAccountsEnabled: False
    redirectUris:
      - "https://angular-frontend.tua.xy.io/*"
    webOrigins: 
      - "+"
```

2. Check the client that has been create in Keycloak via Browser, 
The field "Direct Access Grants Enabled" is on without the fix and off if the fix is applied.


## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->