### PR TITLE
KEYCLOAK-13711  Change of attribute POSTGRES_EXTERNAL_ADDRESS in secret keycloak-db-secret not handled

### DIFF
--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -131,7 +131,7 @@ func (i *KeycloakReconciler) getPostgresqlServiceDesiredState(clusterState *comm
 		}
 	}
 	return common.GenericUpdateAction{
-		Ref: model.PostgresqlServiceReconciled(clusterState.PostgresqlService),
+		Ref: model.PostgresqlServiceReconciled(clusterState.PostgresqlService, clusterState.DatabaseSecret, isExternal),
 		Msg: "Update Postgresql KeycloakService",
 	}
 }


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-13711

## Additional Information

If the attribute POSTGRES_EXTERNAL_ADDRESS in secret keycloak-db-secret is changed from a dns-name to an ip-address or vice-versa, the service keycloak-postgresql is not adapted accordingly.



## Verification Steps
I discovered this in a setup with an external database.

Keycloak-CRD:
```
apiVersion: keycloak.org/v1alpha1
kind: Keycloak
metadata:
  name: keycloak
  labels:
    app: sso
    test: sso
spec:
  instances: 1
  extensions:
    - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
  externalAccess:
    enabled: False
  externalDatabase:
    enabled: True
  podDisruptionBudget:
    enabled: True
```
and a secret like this 
```
apiVersion: v1
data:
  POSTGRES_DATABASE: cG9zdGdyZXNxbA==
  POSTGRES_EXTERNAL_ADDRESS: MS4xLjEuMQ==
  POSTGRES_EXTERNAL_PORT: NTQzMg==
  POSTGRES_PASSWORD: MldNcHFxRzlwcG1wa2h2Vg==
  POSTGRES_SUPERUSER: dHJ1ZQ==
  POSTGRES_USERNAME: cm9vdA==
kind: Secret
metadata:
  labels:
    app: keycloak
  name: keycloak-db-secret
  namespace: keycloak
type: Opaque
```

The error can be reproduced by changing the attribute POSTGRES_EXTERNAL_ADDRESS in secret keycloak-db-secret with the command (add namespace to command).

```
kubectl edit secret keycloak-db-secret
```
and checking the service with
```
kubectl get svc keycloak-postgresql
```
## Checklist:
- [ ] Verified by team member
- [x] Comments where necessary
- [x] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
none