### PR TITLE
KEYCLOAK-13743 Do not panic on missing Keycloak cluster

### DIFF
--- a/pkg/common/controller_utils.go
+++ b/pkg/common/controller_utils.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"reflect"
 
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,11 +68,7 @@ func GetMatchingKeycloaks(ctx context.Context, c client.Client, labelSelector *v
 	}
 
 	err := c.List(ctx, &list, opts...)
-	if err != nil {
-		return list, err
-	}
-
-	return list, nil
+	return list, validateList(err, list.Items)
 }
 
 // Try to get a list of keycloak instances that match the selector specified on the realm
@@ -82,9 +79,17 @@ func GetMatchingRealms(ctx context.Context, c client.Client, labelSelector *v1.L
 	}
 
 	err := c.List(ctx, &list, opts...)
-	if err != nil {
-		return list, err
-	}
+	return list, validateList(err, list.Items)
+}
 
-	return list, nil
+func validateList(previousError error, list interface{}) error {
+	if previousError != nil {
+		return previousError
+	}
+	listVal := reflect.ValueOf(list)
+	if listVal.Len() == 0 {
+		err := fmt.Errorf("could not find matching %v objects", listVal.Type())
+		return err
+	}
+	return nil
 }

--- a/pkg/common/controller_utils_test.go
+++ b/pkg/common/controller_utils_test.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUtil_Test_validateList_With_Previous_Error(t *testing.T) {
+	// given
+	err := fmt.Errorf("testError")
+	var items []v1alpha1.KeycloakRealm
+
+	// when
+	returnedError := validateList(err, items)
+
+	// then
+	assert.Equal(t, err, returnedError)
+}
+
+func TestUtil_Test_validateList_With_Empty_List(t *testing.T) {
+	// given
+	var items []v1alpha1.KeycloakRealm
+
+	// when
+	returnedError := validateList(nil, items)
+
+	// then
+	assert.NotNil(t, returnedError)
+}
+
+func TestUtil_Test_validateList_With_Proper_Arguments(t *testing.T) {
+	// given
+	items := []string{"test"}
+
+	// when
+	returnedError := validateList(nil, items)
+
+	// then
+	assert.Nil(t, returnedError)
+}


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
[KEYCLOAK-13743](https://issues.redhat.com/browse/KEYCLOAK-13743)

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
This Pull Request fixes an error reported in https://github.com/operator-framework/community-operators/pull/1479. The reason Travis failed in the Operatorhub was that `KeycloakBackup` CR was pointing to a non-existing Keycloak cluster. 

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->