### PR TITLE
Lower alert severity for memory based alerts

### DIFF
--- a/pkg/model/prometheus_rule.go
+++ b/pkg/model/prometheus_rule.go
@@ -17,7 +17,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`100 * jvm_memory_bytes_used{area="heap",namespace="` + cr.Namespace + `"} / jvm_memory_bytes_max{area="heap",namespace="` + cr.Namespace + `"} > 90`),
 		For:  "1m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}, {
 		Alert: "KeycloakJavaNonHeapThresholdExceeded",
@@ -27,7 +27,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`100 * jvm_memory_bytes_used{area="nonheap",namespace="` + cr.Namespace + `"} / jvm_memory_bytes_max{area="nonheap",namespace="` + cr.Namespace + `"} > 90`),
 		For:  "1m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}, {
 		Alert: "KeycloakJavaGCTimePerMinuteScavenge",
@@ -37,7 +37,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`increase(jvm_gc_collection_seconds_sum{gc="PS Scavenge",namespace="` + cr.Namespace + `"}[1m]) > 1 * 60 * 0.9`),
 		For:  "1m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}, {
 		Alert: "KeycloakJavaGCTimePerMinuteMarkSweep",
@@ -47,7 +47,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`increase(jvm_gc_collection_seconds_sum{gc="PS MarkSweep",namespace="` + cr.Namespace + `"}[1m]) > 1 * 60 * 0.9`),
 		For:  "1m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}, {
 		Alert: "KeycloakJavaDeadlockedThreads",


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/INTLY-6614

## Additional Information
Some discussion in https://issues.redhat.com/browse/INTLY-6614, the gist of which is a review of the critical alerts and if they should be critical (i.e. they page someone when they fire).

My thinking is that only problems that affect a potential service level objective (SLO) should be critical.
In this case, its:
- `KeycloakInstanceNotAvailable` if the service isn't available
- `KeycloakAPIRequestDuration90PercThresholdExceeded` & `KeycloakAPIRequestDuration99.5PercThresholdExceeded` if the service isn't responding as fast as expected

All other alerts would help with debugging & point at potential causes as to why one of the critical alerts are firing, but as long as the SLO is being met, no-one needs to be paged.


## Verification Steps
1. Install operator in a cluster with prometheus-operator
2. Verify the alerts are created with the expected severity

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->