### PR TITLE
adds attributes field to KeycloakUser CRD

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -295,6 +295,13 @@ spec:
                   description: A set of Keycloak Users.
                   items:
                     properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: A set of Attributes.
+                        type: object
                       clientRoles:
                         additionalProperties:
                           items:

--- a/deploy/crds/keycloak.org_keycloakusers_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakusers_crd.yaml
@@ -77,6 +77,13 @@ spec:
             user:
               description: Keycloak User REST object.
               properties:
+                attributes:
+                  additionalProperties:
+                    items:
+                      type: string
+                    type: array
+                  description: A set of Attributes.
+                  type: object
                 clientRoles:
                   additionalProperties:
                     items:

--- a/pkg/apis/keycloak/v1alpha1/keycloakuser_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakuser_types.go
@@ -87,6 +87,9 @@ type KeycloakAPIUser struct {
 	// A set of Credentials.
 	// +optional
 	Credentials []KeycloakCredential `json:"credentials,omitempty"`
+	// A set of Attributes.
+	// +optional
+	Attributes map[string][]string `json:"attributes,omitempty"`
 }
 
 type KeycloakCredential struct {

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -277,6 +277,21 @@ func (in *KeycloakAPIUser) DeepCopyInto(out *KeycloakAPIUser) {
 		*out = make([]KeycloakCredential, len(*in))
 		copy(*out, *in)
 	}
+	if in.Attributes != nil {
+		in, out := &in.Attributes, &out.Attributes
+		*out = make(map[string][]string, len(*in))
+		for key, val := range *in {
+			var outVal []string
+			if val == nil {
+				(*out)[key] = nil
+			} else {
+				in, out := &val, &outVal
+				*out = make([]string, len(*in))
+				copy(*out, *in)
+			}
+			(*out)[key] = outVal
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
## JIRA ID

Adds attributes field to KeycloakUser CRD.

https://issues.redhat.com/browse/INTLY-6491

## Additional Information

The attributes field is missing in KeycloakUser CRD and we want to be able to use this field to flag when users are created in other products in the [RHMI operator](https://github.com/integr8ly/integreatly-operator)

https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_userrepresentation

