### PR TITLE
Lower severity of rate based alerts

### DIFF
--- a/pkg/model/prometheus_rule.go
+++ b/pkg/model/prometheus_rule.go
@@ -87,7 +87,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`(sum(rate(keycloak_request_duration_bucket{le="1000.0", namespace="` + cr.Namespace + `"}[5m])) by (job) / sum(rate(keycloak_request_duration_count{namespace="` + cr.Namespace + `"}[5m])) by (job)) < 0.90`),
 		For:  "5m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}, {
 		Alert: "KeycloakAPIRequestDuration99.5PercThresholdExceeded",
@@ -97,7 +97,7 @@ func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 		Expr: intstr.FromString(`(sum(rate(keycloak_request_duration_bucket{le="10000.0", namespace="` + cr.Namespace + `"}[5m])) by (job) / sum(rate(keycloak_request_duration_count{namespace="` + cr.Namespace + `"}[5m])) by (job)) < 0.995`),
 		For:  "5m",
 		Labels: map[string]string{
-			"severity": "critical",
+			"severity": "warning",
 		},
 	}}
 


### PR DESCRIPTION
Discussed offline (& in https://issues.redhat.com/browse/INTLY-6614) 
I think it might be best to go down to just 1 critical alert where SRE need to investigate as a matter of urgency at this time i.e. the 'up' alert (KeycloakInstanceNotAvailable).

The response times alerts may become more important in time, but I don't think we know what immediate steps an SRE could take when paged, so i think lowering them to warning is reasonable.
There could be an immediate action to increase the number of instances (in the keycloak CR) while investigation continues, but i'd like to have that discussion with our SRE team first as there's resourcing concerns there. Also, they Keycloak CR gets reset back to 2 in RHMI whenever changed at the moment (David Ffrench is following up on that to allow changes)

TLDR: Just have the 'up' alert for at least 1 keycloak pod as critical.
All others as warning, but will add gained knowledge from discussions here to the SOP to help with debugging any warnings related to memory & GC.

## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Additional Information
https://issues.redhat.com/browse/INTLY-6614

## Verification Steps
1. Install in a cluster with prometheus-operator watching the ns 
2. Verify the severity of alerts in Prometheus Alerts tab reflects the chagnes

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->