### PR TITLE
KEYCLOAK-13616 Setup for the product

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,15 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 AS build-env
 
 RUN microdnf install -y git make golang
 
-ADD ./ /src
+COPY . /src/
 RUN cd /src && make code/compile
 RUN cd /src && echo "Build SHA1: $(git rev-parse HEAD)"
 RUN cd /src && echo "$(git rev-parse HEAD)" > /src/BUILD_INFO
 
 # final stage
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+##LABELS
 
 RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum/*
 

--- a/container.yaml
+++ b/container.yaml
@@ -1,0 +1,10 @@
+compose:
+  pulp_repos: true
+go:
+  modules:
+    - module: github.com/keycloak/keycloak-operator
+image_build_method: imagebuilder
+platforms:
+  only:
+    - x86_64
+    - s390x

--- a/content_sets.yaml
+++ b/content_sets.yaml
@@ -1,0 +1,9 @@
+ppc64le:
+  - rhel-8-for-ppc64le-baseos-rpms
+  - rhel-8-for-ppc64le-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
+x86_64:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms

--- a/productize.sh
+++ b/productize.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+LABELS=$(cat <<-END
+LABEL \
+com.redhat.component="redhat-sso-7-sso74-operator-rhel8-container"  \
+description="Red Hat Single Sign-On 7.4 Operator container image, based on the Red Hat Universal Base Image 8 Minimal container image" \
+summary="Red Hat Single Sign-On 7.4 Operator container image, based on the Red Hat Universal Base Image 8 Minimal container image" \
+version="7.4" \
+io.k8s.description="Operator for Red Hat SSO" \
+io.k8s.display-name="Red Hat SSO 7.4 Operator" \
+io.openshift.tags="sso,sso74,keycloak,operator" \
+name="rh-sso-7\/sso74-operator-rhel8" \
+maintainer="Red Hat Single Sign-On Team"
+END
+)
+
+sed -i 's/registry.access.redhat.com\/ubi8\/ubi-minimal:8.1/ubi8-minimal:8-released/' Dockerfile
+sed -i -e 's/FROM registry.access.redhat.com\/ubi8\/ubi-minimal:[0-9.]*/FROM ubi8-minimal:8-released/' \
+    -e "s/##LABELS/$LABELS/g" \
+    Dockerfile


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-13616

This Pull Request introduces a setup required for building both Keycloak and RHSSO from the same repo. OSBS (which is used by the product) requires additional YAML files (added by this commit). I also introduced `productize.sh` script, which replaces `Dockerfile` with the on prepared specially for OSBS.