### PR TITLE
KEYCLOAK-14016 Support for testing operator as an image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,12 @@ test/e2e: cluster/prepare
 	# operator-sdk test  local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count" --namespace ${NAMESPACE} --up-local --debug --verbose ./test/e2e
 	go test -tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -mod=vendor ./test/e2e/... -root=$(PWD) -kubeconfig=$(HOME)/.kube/config -globalMan deploy/empty-init.yaml -namespacedMan deploy/empty-init.yaml -test.v -singleNamespace -parallel=1 -localOperator -test.timeout 0
 
+.PHONY: test/e2e-image
+test/e2e-image:
+	@echo Running tests with operator as an image in the cluster:
+	# Doesn't need cluster/prepare as it's done by operator-sdk. Uses a randomly generated namespace (instead of keycloak namespace) to support parallel test runs.
+	operator-sdk test local ./test/e2e --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count" --debug --verbose
+
 .PHONY: test/coverage/prepare
 test/coverage/prepare:
 	@echo Preparing coverage file:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: keycloak-operator
           # Replace this with the built image name
-          image: quay.io/keycloak/keycloak-operator:9.0.2
+          image: quay.io/keycloak/keycloak-operator:master
           command:
           - keycloak-operator
           imagePullPolicy: Always

--- a/docs/building.md
+++ b/docs/building.md
@@ -9,9 +9,14 @@
 -- The above step will launch the operator on the local machine
 -- To see how do debug the operator or how to deploy to a cluster, see below alternatives to step 3
 4. In a new terminal run `make cluster/create/examples`
-5. (Optional for Minikube) Configure Ingress and DNS Resolver
--- run `minikube addons enable ingress`
--- run `./hack/modify_etc_hosts.sh`
+5. Optional: configure Ingress and DNS Resolver
+   - minikube: \
+     -- run `minikube addons enable ingress` \
+     -- run `./hack/modify_etc_hosts.sh`
+   - Docker for Mac: \
+     -- run `kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-0.32.0/deploy/static/provider/cloud/deploy.yaml`
+        (see also https://kubernetes.github.io/ingress-nginx/deploy/) \
+     -- run `./hack/modify_etc_hosts.sh keycloak.local 127.0.0.1`
 
 To clean the cluster (Removes CRDs, CRs, RBAC and namespace)
 1. run `make cluster/clean`
@@ -67,12 +72,13 @@ Deploy the operator into the running cluster
 | `make cluster/create/examples` | Applies the example Keycloak and KeycloakRealm CRs                                                     |
 
 #### Tests
-| *Command*                    | *Description*                                           |
-| ---------------------------- | ------------------------------------------------------- |
-| `make test/unit`             | Runs unit tests                                         |
-| `make test/e2e`              | Runs e2e tests                                          |
-| `make test/coverage/prepare` | Prepares coverage report from unit and e2e test results |
-| `make test/coverage`         | Generates coverage report                               |
+| *Command*                    | *Description*                                               |
+| ---------------------------- | ----------------------------------------------------------- |
+| `make test/unit`             | Runs unit tests                                             |
+| `make test/e2e`              | Runs e2e tests with operator ran locally                    |
+| `make test/e2e-image`        | Runs e2e tests with operator ran as an image in the cluster |
+| `make test/coverage/prepare` | Prepares coverage report from unit and e2e test results     |
+| `make test/coverage`         | Generates coverage report                                   |
 
 #### Local Development
 | *Command*                 | *Description*                                                                    |

--- a/test/e2e/constants.go
+++ b/test/e2e/constants.go
@@ -4,6 +4,7 @@ import "time"
 
 const (
 	testKeycloakCRName   = "keycloak-test"
+	operatorCRName       = "keycloak-operator"
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 10
 	pollRetryInterval    = time.Second * 10

--- a/test/e2e/keycloak_main_test.go
+++ b/test/e2e/keycloak_main_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/keycloak/keycloak-operator/pkg/apis"
@@ -49,9 +50,17 @@ func runTestsFromCRDInterface(t *testing.T, crd *CRDTestStruct) {
 		// get global framework variables
 		f := framework.Global
 		// wait for Keycloak Operator to be ready
-		err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, testKeycloakCRName, 1, pollRetryInterval, pollTimeout)
+		err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, operatorCRName, 1, pollRetryInterval, pollTimeout)
 		if err != nil {
 			t.Fatal(err)
+		}
+
+		if !f.LocalOperator {
+			deployment, err := f.KubeClient.AppsV1().Deployments(namespace).Get(operatorCRName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("Operator deployed from: %s", deployment.Spec.Template.Spec.Containers[0].Image)
 		}
 
 		for _, prepareEnvironmentFunction := range crd.prepareEnvironmentSteps {


### PR DESCRIPTION
## JIRA ID
[KEYCLOAK-14016](https://issues.redhat.com/browse/KEYCLOAK-14016)

## Additional Information
* Adds `test/e2e-image` make target to execute the tests with operator deployed to the cluster (as opposed to `test/e2e` which executes the operator locally while testing). This uses the `operator-sdk` CLI tool to automatically prepare the environment in a random namespace. From my PoV it doesn't make much sense to run this target in Travis as it uses an operator image and doesn't build and deploy the operator image.
* Fixes `WaitForOperatorDeployment` to use correct CR name.
* Updates docs on how to use ingress with Docker's K8s.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
I was not able to get `test/e2e-image` working with Ingress on my local machine. The operator doesn't seem to "communicate" with Ingress when deployed to the container (`test/e2e` works fine). Maybe I'm just doing something wrong. In any case, it's passing with OCP 4, so I'm not sure if it's even important for this to work locally as well.