### PR TITLE
Upstream/downstream Dockerfile proposal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,32 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 AS build-env
+# This Dockerfile is used for building Red Hat Single Sign-On Operator.
+# If you're looking for a Dockerfile for Keycloak, please look at Dockerfile.keycloak
+
+FROM ubi8-minimal:8-released AS build-env
 
 RUN microdnf install -y git make golang
 
-ADD ./ /src
+COPY . /src/
 RUN cd /src && make code/compile
 RUN cd /src && echo "Build SHA1: $(git rev-parse HEAD)"
 RUN cd /src && echo "$(git rev-parse HEAD)" > /src/BUILD_INFO
 
 # final stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+FROM ubi8-minimal:8-released
 
-RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum/*
+LABEL \
+    com.redhat.component="redhat-sso-7-sso74-operator-rhel8-container"  \
+    description="Red Hat Single Sign-On 7.4 Operator on OpenJDK OpenShift container image, based on the Red Hat Universal Base Image 8 Minimal container image" \
+    summary="Red Hat Single Sign-On 7.4 Operator on OpenJDK OpenShift container image, based on the Red Hat Universal Base Image 8 Minimal container image" \
+    version="7.4" \
+    io.k8s.description="Operator for Red Hat SSO" \
+    io.k8s.display-name="Red Hat SSO 7.4 Operator" \
+    io.openshift.tags="sso,sso74,keycloak,operator" \
+    name="rh-sso-7/sso74-operator-rhel8" \
+    maintainer="Red Hat Single Sign-On Team"
 
 COPY --from=build-env /src/BUILD_INFO /src/BUILD_INFO
 COPY --from=build-env /src/tmp/_output/bin/keycloak-operator /usr/local/bin
 
-ENTRYPOINT ["/usr/local/bin/keycloak-operator"]
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}

--- a/Dockerfile.keycloak
+++ b/Dockerfile.keycloak
@@ -1,0 +1,21 @@
+# This Dockerfile is used for building Keycloak Operator.
+# If you're looking for a Dockerfile for Red Hat Single Sign-On, please look at Dockerfile
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1 AS build-env
+
+RUN microdnf install -y git make golang
+
+ADD ./ /src
+RUN cd /src && make code/compile
+RUN cd /src && echo "Build SHA1: $(git rev-parse HEAD)"
+RUN cd /src && echo "$(git rev-parse HEAD)" > /src/BUILD_INFO
+
+# final stage
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.1
+
+RUN microdnf update && microdnf clean all && rm -rf /var/cache/yum/*
+
+COPY --from=build-env /src/BUILD_INFO /src/BUILD_INFO
+COPY --from=build-env /src/tmp/_output/bin/keycloak-operator /usr/local/bin
+
+ENTRYPOINT ["/usr/local/bin/keycloak-operator"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,1 +1,1 @@
-../Dockerfile
+../Dockerfile.keycloak


### PR DESCRIPTION
This Pull Request represents a proposal for hosting both upstream and downstream `Dockerfile`. As OSBS doesn't allow to use any other `Dockerfile` location, this is why the default needs to be set to the RHSSO one. Quay is much more liberal here and it allows to select `Dockerfile` location.