### PR TITLE
KEYCLOAK-14075 Downgrade to Postgresql 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ All images used by the Operator might be controlled using dedicated Environmenta
  | `RHSSO` for OpenJDK | `IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | Init container      | `IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                |
  | Backup container    | `IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.10`                    |
- | Postgresql          | `IMAGE_POSTGRESQL`              | `postgres:11.5`                                                  |
+ | Postgresql          | `IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
 
 ## Contributing
 

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -26,7 +26,7 @@ const (
 	// Required by the Integreately Backup Image
 	DatabaseSecretDatabaseProperty = "POSTGRES_DATABASE" // nolint
 	// Required by the Integreately Backup Image
-	DatabaseSecretSuperuserProperty       = "POSTGRES_SUPERUSER"        // nolint
+	DatabaseSecretVersionProperty         = "POSTGRES_VERSION"          // nolint
 	DatabaseSecretExternalAddressProperty = "POSTGRES_EXTERNAL_ADDRESS" // nolint
 	DatabaseSecretExternalPortProperty    = "POSTGRES_EXTERNAL_PORT"    // nolint
 	KeycloakServicePort                   = 8443

--- a/pkg/model/database_secret.go
+++ b/pkg/model/database_secret.go
@@ -20,9 +20,9 @@ func DatabaseSecret(cr *v1alpha1.Keycloak) *v1.Secret {
 			DatabaseSecretUsernameProperty: PostgresqlUsername,
 			DatabaseSecretPasswordProperty: cr.ObjectMeta.Name + "-" + GenerateRandomString(PostgresqlPasswordLength),
 			// The 3 entries below are not used by the Operator itself but rather by the Backup container
-			DatabaseSecretDatabaseProperty:  PostgresqlDatabase,
-			DatabaseSecretSuperuserProperty: "true",
-			DatabaseSecretHostProperty:      PostgresqlServiceName,
+			DatabaseSecretDatabaseProperty: PostgresqlDatabase,
+			DatabaseSecretHostProperty:     PostgresqlServiceName,
+			DatabaseSecretVersionProperty:  "10",
 		},
 	}
 }
@@ -46,11 +46,11 @@ func DatabaseSecretReconciled(cr *v1alpha1.Keycloak, currentState *v1.Secret) *v
 	if _, ok := reconciled.Data[DatabaseSecretDatabaseProperty]; !ok {
 		reconciled.StringData[DatabaseSecretDatabaseProperty] = PostgresqlDatabase
 	}
-	if _, ok := reconciled.Data[DatabaseSecretSuperuserProperty]; !ok {
-		reconciled.StringData[DatabaseSecretSuperuserProperty] = "true"
-	}
 	if _, ok := reconciled.Data[DatabaseSecretHostProperty]; !ok {
 		reconciled.StringData[DatabaseSecretHostProperty] = PostgresqlServiceName
+	}
+	if _, ok := reconciled.Data[DatabaseSecretVersionProperty]; !ok {
+		reconciled.StringData[DatabaseSecretVersionProperty] = "10"
 	}
 	return reconciled
 }

--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -18,8 +18,8 @@ const (
 	DefaultRHSSOImageOpenJ9      = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1"
 	DefaultRHSSOImageOpenJDK     = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1"
 	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:master"
-	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.10"
-	DefaultPostgresqlImage       = "postgres:11.5"
+	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.14"
+	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"
 )
 
 var Images = NewImageManager()

--- a/pkg/model/postgresql_backup.go
+++ b/pkg/model/postgresql_backup.go
@@ -36,7 +36,7 @@ func PostgresqlBackup(cr *v1alpha1.KeycloakBackup) *v13.Job {
 							Name:    cr.Name,
 							Image:   Images.Images[PostgresqlImage],
 							Command: []string{"/bin/sh", "-c"},
-							Args:    []string{"pg_dumpall --clean --if-exists --oids | tee /backup/backup.sql"},
+							Args:    []string{"pg_dump $POSTGRES_DB | tee /backup/backup.sql"},
 							Env: []v1.EnvVar{
 								{
 									Name: "POSTGRES_USER",
@@ -120,7 +120,7 @@ func PostgresqlBackupReconciled(cr *v1alpha1.KeycloakBackup, currentState *v13.J
 			Name:    cr.Name,
 			Image:   Images.Images[PostgresqlImage],
 			Command: []string{"/bin/sh", "-c"},
-			Args:    []string{"pg_dumpall --clean --if-exists --oids | tee /backup/backup.sql"},
+			Args:    []string{"pg_dump $POSTGRES_DB | tee /backup/backup.sql"},
 			Env: []v1.EnvVar{
 				{
 					Name: "POSTGRES_USER",

--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -54,7 +54,7 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 										Command: []string{
 											"/bin/sh",
 											"-c",
-											"psql -h 127.0.0.1 -U $POSTGRES_USER -q -d $POSTGRES_DB -c 'SELECT 1'",
+											"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'",
 										},
 									},
 								},
@@ -70,7 +70,7 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 							},
 							Env: []v1.EnvVar{
 								{
-									Name: "POSTGRES_USER",
+									Name: "POSTGRESQL_USER",
 									ValueFrom: &v1.EnvVarSource{
 										SecretKeyRef: &v1.SecretKeySelector{
 											LocalObjectReference: v1.LocalObjectReference{
@@ -81,18 +81,7 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 									},
 								},
 								{
-									Name: "PGUSER",
-									ValueFrom: &v1.EnvVarSource{
-										SecretKeyRef: &v1.SecretKeySelector{
-											LocalObjectReference: v1.LocalObjectReference{
-												Name: DatabaseSecretName,
-											},
-											Key: DatabaseSecretUsernameProperty,
-										},
-									},
-								},
-								{
-									Name: "POSTGRES_PASSWORD",
+									Name: "POSTGRESQL_PASSWORD",
 									ValueFrom: &v1.EnvVarSource{
 										SecretKeyRef: &v1.SecretKeySelector{
 											LocalObjectReference: v1.LocalObjectReference{
@@ -103,19 +92,14 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 									},
 								},
 								{
-									Name:  "POSTGRES_DB",
+									Name:  "POSTGRESQL_DATABASE",
 									Value: PostgresqlDatabase,
-								},
-								{
-									// Due to permissions issue, we need to create a subdirectory in the PVC
-									Name:  "PGDATA",
-									Value: "/var/lib/postgresql/data/pgdata",
 								},
 							},
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      PostgresqlPersistentVolumeName,
-									MountPath: "/var/lib/postgresql/data",
+									MountPath: "/var/lib/pgsql/data",
 								},
 							},
 						},
@@ -170,7 +154,7 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 						Command: []string{
 							"/bin/sh",
 							"-c",
-							"psql -h 127.0.0.1 -U $POSTGRES_USER -q -d $POSTGRES_DB -c 'SELECT 1'",
+							"psql -h 127.0.0.1 -U $POSTGRESQL_USER -q -d $POSTGRESQL_DATABASE -c 'SELECT 1'",
 						},
 					},
 				},
@@ -186,7 +170,7 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 			},
 			Env: []v1.EnvVar{
 				{
-					Name: "POSTGRES_USER",
+					Name: "POSTGRESQL_USER",
 					ValueFrom: &v1.EnvVarSource{
 						SecretKeyRef: &v1.SecretKeySelector{
 							LocalObjectReference: v1.LocalObjectReference{
@@ -197,18 +181,7 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 					},
 				},
 				{
-					Name: "PGUSER",
-					ValueFrom: &v1.EnvVarSource{
-						SecretKeyRef: &v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: DatabaseSecretName,
-							},
-							Key: DatabaseSecretUsernameProperty,
-						},
-					},
-				},
-				{
-					Name: "POSTGRES_PASSWORD",
+					Name: "POSTGRESQL_PASSWORD",
 					ValueFrom: &v1.EnvVarSource{
 						SecretKeyRef: &v1.SecretKeySelector{
 							LocalObjectReference: v1.LocalObjectReference{
@@ -219,13 +192,8 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 					},
 				},
 				{
-					Name:  "POSTGRES_DB",
+					Name:  "POSTGRESQL_DATABASE",
 					Value: PostgresqlDatabase,
-				},
-				{
-					// Due to permissions issue, we need to create a subdirectory in the PVC
-					Name:  "PGDATA",
-					Value: "/var/lib/postgresql/data/pgdata",
 				},
 			},
 			VolumeMounts: []v1.VolumeMount{

--- a/test/e2e/keycloak_main_test.go
+++ b/test/e2e/keycloak_main_test.go
@@ -1,8 +1,9 @@
 package e2e
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/keycloak/keycloak-operator/pkg/apis"
 	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
[KEYCLOAK-14075](https://issues.redhat.com/browse/KEYCLOAK-14075)
[KEYCLOAK-13399](https://issues.redhat.com/browse/KEYCLOAK-13399)

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
As agreed with @iankko and @pdrozd, we need to downgrade Postgresql to 10 for both Keycloak and the product (to be consistent). This also requires upgrading RHMI Backup Container and adding additional Postgresql version in order to use backups.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->