### PR TITLE
KEYCLOAK-13634 Allow a single RHSSO image override

### DIFF
--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -51,6 +51,11 @@ func (p *ImageManager) getImage(environmentalVariable string, defaultValue strin
 }
 
 func (p *ImageManager) getRHSSOImage() string {
+	defaultImage := p.getDefaultRHSSOImageForCurrentArchitecture()
+	return p.getImage(RHSSOImage, defaultImage)
+}
+
+func (p *ImageManager) getDefaultRHSSOImageForCurrentArchitecture() string {
 	// Full list of archs might be found here:
 	// https://github.com/golang/go/blob/release-branch.go1.10/src/go/build/syslist.go#L8
 	switch arch := runtime.GOARCH; arch {

--- a/pkg/model/image_manager_test.go
+++ b/pkg/model/image_manager_test.go
@@ -31,3 +31,35 @@ func TestImageManager_test_defining_image_using_environment_variable(t *testing.
 	//then
 	assert.Equal(t, "test", imageChooser.Images[KeycloakImage])
 }
+
+func TestImageManager_test_overriding_rhsso_image_using_environment_variable(t *testing.T) {
+	//given
+	os.Setenv(RHSSOImage, "test")
+
+	//when
+	imageChooser := NewImageManager()
+	os.Unsetenv(RHSSOImage)
+
+	//then
+	assert.Equal(t, "test", imageChooser.Images[RHSSOImage])
+}
+
+func TestImageManager_test_overriding_multiple_images_using_environment_variables(t *testing.T) {
+	//given
+	os.Setenv(RHSSOImage, "RHSSOImage")
+	os.Setenv(RHSSOImageOpenJ9, "RHSSOImageOpenJ9")
+	os.Setenv(RHSSOImageOpenJDK, "RHSSOImageOpenJDK")
+
+	//when
+	imageChooser := NewImageManager()
+	getRHSSOImageResult := imageChooser.getRHSSOImage()
+	os.Unsetenv(RHSSOImage)
+	os.Unsetenv(RHSSOImageOpenJ9)
+	os.Unsetenv(RHSSOImageOpenJDK)
+
+	//then
+	assert.Equal(t, "RHSSOImage", getRHSSOImageResult)
+	assert.Equal(t, "RHSSOImage", imageChooser.Images[RHSSOImage])
+	assert.Equal(t, "RHSSOImageOpenJ9", imageChooser.Images[RHSSOImageOpenJ9])
+	assert.Equal(t, "RHSSOImageOpenJDK", imageChooser.Images[RHSSOImageOpenJDK])
+}


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
[KEYCLOAK-13634](https://issues.redhat.com/browse/KEYCLOAK-13634)

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
As agreed with @ASzc and @hmlnarik, we introduced a convenient option for overriding all RHSSO images (for both architectures). In such a case, you need to override `RELATED_IMAGE_RHSSO` env. variable.

## Verification Steps
<!--
Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->