### PR TITLE
[KEYCLOAK-14083] Run golangci-lint as part of pull request workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,27 @@
+name: Go
+
+on: [push, pull_request]
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go mod verify
+
+    - name: Build
+      run: |
+        go test ./...
+        go build -v .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v0.1.7
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: v1.26
+          github-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## [KEYCLOAK-14083](https://issues.redhat.com/browse/KEYCLOAK-14083)
This change introduce the usage of GolangCI linter with GH actions

## Additional Information
* [Example of GH actions working](https://github.com/arkham-labs/louketo-proxy/actions/runs/98490210)
* Output from the last run against Keycloak Operator repository - https://github.com/abstractj/keycloak-operator/actions/runs/99048680