### PR TITLE
KEYCLOAK-14278 Fix isResourcesReady postgres deployment

### DIFF
--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -472,15 +472,21 @@ func (i *ClusterState) readPodDisruptionCurrentState(context context.Context, cr
 	return nil
 }
 
-func (i *ClusterState) IsResourcesReady() (bool, error) {
+func (i *ClusterState) IsResourcesReady(cr *kc.Keycloak) (bool, error) {
 	// Check keycloak statefulset is ready
 	keycloakDeploymentReady, _ := IsStatefulSetReady(i.KeycloakDeployment)
 	// Default Route ready to true in case we are running on native Kubernetes
 	keycloakRouteReady := true
+
 	// Check keycloak postgres deployment is ready
 	postgresqlDeploymentReady, err := IsDeploymentReady(i.PostgresqlDeployment)
 	if err != nil {
 		return false, err
+	}
+
+	// If the instance is using an external database, always set to true
+	if cr.Spec.ExternalDatabase.Enabled {
+		postgresqlDeploymentReady = true
 	}
 
 	// If running on OpenShift, check the Route is ready

--- a/pkg/controller/keycloak/keycloak_controller.go
+++ b/pkg/controller/keycloak/keycloak_controller.go
@@ -219,7 +219,7 @@ func (r *ReconcileKeycloak) ManageError(instance *v1alpha1.Keycloak, issue error
 
 func (r *ReconcileKeycloak) ManageSuccess(instance *v1alpha1.Keycloak, currentState *common.ClusterState) (reconcile.Result, error) {
 	// Check if the resources are ready
-	resourcesReady, err := currentState.IsResourcesReady()
+	resourcesReady, err := currentState.IsResourcesReady(instance)
 	if err != nil {
 		return r.ManageError(instance, err)
 	}


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-14278

## Additional Information
During the [ManageSuccess function](https://github.com/keycloak/keycloak-operator/blob/master/pkg/controller/keycloak/keycloak_controller.go#L222-L235) of the keycloak CR controller, the secondary resources are checked to see if they are in a ready state. This is reported in the Keycloak CR status.

The [isResourcesReady function](https://github.com/keycloak/keycloak-operator/blob/master/pkg/common/cluster_state.go#L481) does not take into account if an external database is used and will also report not ready because the postgresql deployment resource doesn't exist.

## Verification Steps
1. Create a Keycloak CR with externalDatabase enabled
2. Verify the Keycloak CR status reports ready:true and phase:reconciling


## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->