### PR TITLE
Fix generation of keycloak client 

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -14,7 +14,7 @@ spec:
     status: {}
   validation:
     openAPIV3Schema:
-      description: Keycloak is the Schema for the keycloaks API
+      description: Keycloak is the Schema for the keycloaks API .
       properties:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
@@ -29,7 +29,7 @@ spec:
         metadata:
           type: object
         spec:
-          description: KeycloakSpec defines the desired state of Keycloak.
+          description: KeycloakSpec defines the desired state of Keycloak. .
           properties:
             extensions:
               description: A list of extensions, where each one is a URL to a JAR
@@ -140,7 +140,7 @@ spec:
               type: string
           type: object
         status:
-          description: KeycloakStatus defines the observed state of Keycloak
+          description: KeycloakStatus defines the observed state of Keycloak. .
           properties:
             credentialSecret:
               description: The secret where the admin credentials are to be found

--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -69,7 +69,7 @@ type KeycloakAPIClient struct {
 	ConsentRequired bool `json:"consentRequired,omitempty"`
 	// True if Standard flow is enabled.
 	// +optional
-	StandardFlowEnabled bool `json:"standardFlowEnabled,omitempty"`
+	StandardFlowEnabled bool `json:"standardFlowEnabled"`
 	// True if Implicit flow is enabled.
 	// +optional
 	ImplicitFlowEnabled bool `json:"implicitFlowEnabled,omitempty"`
@@ -81,7 +81,7 @@ type KeycloakAPIClient struct {
 	ServiceAccountsEnabled bool `json:"serviceAccountsEnabled,omitempty"`
 	// True if this is a public Client.
 	// +optional
-	PublicClient bool `json:"publicClient,omitempty"`
+	PublicClient bool `json:"publicClient"`
 	// True if this client supports Front Channel logout.
 	// +optional
 	FrontchannelLogout bool `json:"frontchannelLogout,omitempty"`

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
@@ -36,7 +36,7 @@ func schema_pkg_apis_keycloak_v1alpha1_Keycloak(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Keycloak is the Schema for the keycloaks API",
+				Description: "Keycloak is the Schema for the keycloaks API .",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
@@ -531,7 +531,7 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakSpec(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "KeycloakSpec defines the desired state of Keycloak.",
+				Description: "KeycloakSpec defines the desired state of Keycloak. .",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"extensions": {
@@ -609,7 +609,7 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakStatus(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "KeycloakStatus defines the observed state of Keycloak",
+				Description: "KeycloakStatus defines the observed state of Keycloak. .",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"phase": {

--- a/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
+++ b/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
@@ -183,7 +183,7 @@ func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 	assert.IsType(t, model.ClientSecretReconciled(cr, currentState.ClientSecret), desiredState[2].(common.GenericUpdateAction).Ref)
 }
 
-func TestKeycloakClientReconciler_Test_Marshal_Client_directAccessGrantsEnabled(t *testing.T) {
+func TestKeycloakClientReconciler_Test_Marshal_Client(t *testing.T) {
 	// given
 	cr := &v1alpha1.KeycloakClient{
 		ObjectMeta: v13.ObjectMeta{
@@ -198,6 +198,8 @@ func TestKeycloakClientReconciler_Test_Marshal_Client_directAccessGrantsEnabled(
 				ClientID:                  "test",
 				Secret:                    "test",
 				DirectAccessGrantsEnabled: false,
+				StandardFlowEnabled:       false,
+				PublicClient:              false,
 			},
 		},
 	}
@@ -209,4 +211,6 @@ func TestKeycloakClientReconciler_Test_Marshal_Client_directAccessGrantsEnabled(
 	// then
 	assert.Nil(t, err, "Client couldn't be marshalled")
 	assert.True(t, strings.Contains(s, "\"directAccessGrantsEnabled\":false"), "Element directAccessGrantsEnabled should not be omitted if false, as keycloaks default is true")
+	assert.True(t, strings.Contains(s, "\"standardFlowEnabled\":false"), "Element standardFlowEnabled should not be omitted if false, as keycloaks default is true")
+	assert.True(t, strings.Contains(s, "\"publicClient\":false"), "Element publicClient should not be omitted if false, as keycloaks default is true")
 }


### PR DESCRIPTION
... when  standardFlowEnabled and publicClient are set to false

## JIRA ID
KEYCLOAK-14088
KEYCLOAK-14134

## Additional Information
I have to create clients that have the fields standardFlowEnabled and publicCLient both set to false.
When the json for the respective keycloak api-call is created, these fields are missing due to the omitempty tag.
But keycloak used the default true for these values so the keycloak client get the wrong defaults.

Current implementation
```
	// True if Standard flow is enabled.
	// +optional
	StandardFlowEnabled bool `json:"standardFlowEnabled,omitempty"`
	// True if this is a public Client.
	// +optional
	PublicClient bool `json:"publicClient,omitempty"`
```





## Verification Steps

Apply this config:
```
apiVersion: keycloak.org/v1alpha1
kind: KeycloakClient
metadata:
  name: client-test
  labels:
    app: sso
spec:
  realmSelector:
    matchLabels:
      app: sso
  client:
    clientId: client-test
    secret: client-secret1
    clientAuthenticatorType: client-secret
    protocol: openid-connect
    publicClient: false
    directAccessGrantsEnabled: False
    standardFlowEnabled: false
    implicitFlowEnabled: False
    serviceAccountsEnabled: true
```
Without the fix the gui shows

![Screenshot from 2020-05-31 15-39-17](https://user-images.githubusercontent.com/9553525/83353757-09316080-a355-11ea-8e95-a4847dc16436.png)


With the fix:

![Screenshot from 2020-05-31 15-38-18](https://user-images.githubusercontent.com/9553525/83353716-d0918700-a354-11ea-8873-08d9c7c20507.png)



## Checklist:
- [ ] Verified by team member
- [ ] Comments where necessary
- [ ] Automated Tests
- [ ] Documentation changes if necessary

## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->