### PR TITLE
change command for makefile code/run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ setup/operator-sdk:
 
 .PHONY: code/run
 code/run:
-	@operator-sdk run --local --namespace=${NAMESPACE}
+	@operator-sdk run local --watch-namespace ${NAMESPACE}
 
 .PHONY: code/compile
 code/compile:


### PR DESCRIPTION
## KEYCLOAK-14367

## Additional Information
According to the latest [manual](https://sdk.operatorframework.io/docs/cli/operator-sdk_run_local/) of Operator-sdk, the current command for code/run in Makefile needs to change

## Additional Notes
```
$ operator-sdk version
operator-sdk version: "v0.18.0"
```

```
$ operator-sdk run --local --namespace=keycloak
Flag --local has been deprecated, use 'run local' instead
Flag --namespace has been deprecated, use --watch-namespaces (with --local) or --operator-namespace (with --olm) instead
INFO[0000] --namespace is deprecated; use --watch-namespace instead.
```