### PR TITLE
KEYCLOAK-14517 Operator container build needs to reflect $BUILD_OPENJ9

### DIFF
--- a/productize.sh
+++ b/productize.sh
@@ -19,3 +19,10 @@ sed -i \
     -e 's/FROM registry.access.redhat.com\/ubi8\/ubi-minimal:[0-9.]*/FROM ubi8-minimal:8-released/' \
     -e "s/##LABELS/$LABELS/g" \
     Dockerfile
+
+if [[ "$BUILD_OPENJ9" != "true" ]]
+then
+    # remove s390x arch from container.yaml
+    # upstream repo should always contain all archs
+    sed -i -e '/\-\ s390x/ s/^#*/#/' container.yaml
+fi


### PR DESCRIPTION
https://issues.redhat.com/browse/KEYCLOAK-14517

There was a commit to fix this in dist-git repo, but container.yaml is rewritten by rsync command.
This is a upstream PR of https://github.com/keycloak/keycloak-operator-prod/pull/4
