### PR TITLE
KEYCLOAK-14559 updating ca bundle env variable with wildcard ca value

### DIFF
--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -88,7 +88,7 @@ func getRHSSOEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 		},
 		{
 			Name:  "X509_CA_BUNDLE",
-			Value: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+			Value: "/var/run/secrets/kubernetes.io/serviceaccount/*.crt",
 		},
 	}
 


### PR DESCRIPTION
## Jira

https://issues.redhat.com/browse/KEYCLOAK-14559

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

Adding wildcard support for ca-cert configuration. This will allow configuration support for both Vanilla k8 & Openshift as the path varies var/run/secrets/kubernetes.io/serviceaccount/ca.crt (K8s) & /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt (Openshift).

Change is already done for `keycloak_deployment.go`. It was pending for `rhsso_deployment.go` this image release: https://github.com/jboss-container-images/redhat-sso-7-openshift-image/releases/tag/v7.4.0.GA-RHBZ-1813894-fix


https://github.com/jboss-container-images/redhat-sso-7-openshift-image/pull/125



## Additional Notes
<!-- PS.: Add images and/or .gifs to illustrate what was changed if this pull request modifies the appearance/output of something presented to the users. -->