### PR TITLE
KEYCLOAK-14573: Using new Red Hat registry for PG image

### DIFF
--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -21,7 +21,7 @@ const (
 	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:master"
 	DefaultRHSSOInitContainer    = "registry.redhat.io/rh-sso-7/sso74-init-container-rhel8:7.4"
 	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.14"
-	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"
+	DefaultPostgresqlImage       = "registry.redhat.io/rhscl/postgresql-10-rhel7:1"
 )
 
 var Images = NewImageManager()


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-14573

## Additional Information
The Red Hat registry moved but was not used for the PostgreSQL image