### PR TITLE
KEYCLOAK-14568 Moving postgres pv mount path values over to constants.go

### DIFF
--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -19,6 +19,7 @@ const (
 	PostgresqlUsername                   = ApplicationName
 	PostgresqlPasswordLength             = 32
 	PostgresqlPersistentVolumeCapacity   = "1Gi"
+	PostgresqlPersistentVolumeMountPath  = "/var/lib/pgsql/data"
 	DatabaseSecretUsernameProperty       = "POSTGRES_USERNAME" // nolint
 	DatabaseSecretPasswordProperty       = "POSTGRES_PASSWORD" // nolint
 	// Required by the Integreately Backup Image

--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -125,7 +125,7 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      PostgresqlPersistentVolumeName,
-									MountPath: "/var/lib/pgsql/data",
+									MountPath: PostgresqlPersistentVolumeMountPath,
 								},
 							},
 							Resources: getPostgresResources(cr),
@@ -226,7 +226,7 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      PostgresqlPersistentVolumeName,
-					MountPath: "/var/lib/postgresql/data",
+					MountPath: PostgresqlPersistentVolumeMountPath,
 				},
 			},
 			Resources: getPostgresResources(cr),


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-14568

## Additional Information

## Verification Steps

## Checklist:

## Additional Notes
Version of https://github.com/keycloak/keycloak-operator/pull/217 with only one commit. Sorry for any confusion.