### PR TITLE
KEYCLOAK-14063. Run e2e tests in a cluster using a fresh image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,17 @@ go: 1.13.x
 
 env:
   global:
-  - CHANGE_MINIKUBE_NONE_USER=true
-  - MINIKUBE_WANTUPDATENOTIFICATION=false
-  - MINIKUBE_WANTREPORTERRORPROMPT=false
-  - MINIKUBE_HOME=$HOME
-  - CHANGE_MINIKUBE_NONE_USER=true
-  - KUBECONFIG=$HOME/.kube/config
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINIKUBE_WANTUPDATENOTIFICATION=false
+    - MINIKUBE_WANTREPORTERRORPROMPT=false
+    - MINIKUBE_HOME=$HOME
+    - CHANGE_MINIKUBE_NONE_USER=true
+    - KUBECONFIG=$HOME/.kube/config
+
+  matrix:
+    - TESTS=test/unit NAMESPACE=default
+    - TESTS=test/e2e NAMESPACE=default
+    - TESTS=test/e2e-local-image test/goveralls NAMESPACE=default
 
 before_install:
   - go get github.com/mattn/goveralls
@@ -20,7 +25,7 @@ before_install:
   - make setup/travis
 
 # Since there's no persistence sharing, we need to run everything in a single stage
-install: make test/unit test/e2e test/goveralls NAMESPACE=default
+install: make $TESTS
 
 after_failure:
   - echo "---- Keycloak Server logs ----"

--- a/Makefile
+++ b/Makefile
@@ -59,11 +59,18 @@ test/e2e: cluster/prepare
 	# operator-sdk test  local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count" --namespace ${NAMESPACE} --up-local --debug --verbose ./test/e2e
 	go test -tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -mod=vendor ./test/e2e/... -root=$(PWD) -kubeconfig=$(HOME)/.kube/config -globalMan deploy/empty-init.yaml -namespacedMan deploy/empty-init.yaml -test.v -singleNamespace -parallel=1 -localOperator -test.timeout 0
 
-.PHONY: test/e2e-image
-test/e2e-image:
+.PHONY: test/e2e-latest-image
+test/e2e-latest-image:
 	@echo Running tests with operator as an image in the cluster:
 	# Doesn't need cluster/prepare as it's done by operator-sdk. Uses a randomly generated namespace (instead of keycloak namespace) to support parallel test runs.
 	operator-sdk test local ./test/e2e --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count" --debug --verbose
+
+.PHONY: test/e2e-local-image cluster/prepare setup/operator-sdk
+test/e2e-local-image: cluster/prepare setup/operator-sdk
+	docker build . -t keycloak-operator:test
+	@echo Running tests:
+	@touch deploy/empty-init.yaml
+	operator-sdk test  local --go-test-flags "-tags=integration -coverpkg ./... -coverprofile cover-e2e.coverprofile -covermode=count -timeout 0" --image="keycloak-operator:test" --namespace ${NAMESPACE} --up-local --debug --verbose ./test/e2e
 
 .PHONY: test/coverage/prepare
 test/coverage/prepare:

--- a/docs/building.md
+++ b/docs/building.md
@@ -76,7 +76,8 @@ Deploy the operator into the running cluster
 | ---------------------------- | ----------------------------------------------------------- |
 | `make test/unit`             | Runs unit tests                                             |
 | `make test/e2e`              | Runs e2e tests with operator ran locally                    |
-| `make test/e2e-image`        | Runs e2e tests with operator ran as an image in the cluster |
+| `make test/e2e-latest-image` | Runs e2e tests with latest available operator image running in the cluster |
+| `make test/e2e-local-image`  | Runs e2e tests with local operator image running in the cluster |
 | `make test/coverage/prepare` | Prepares coverage report from unit and e2e test results     |
 | `make test/coverage`         | Generates coverage report                                   |
 


### PR DESCRIPTION
## JIRA ID
[KEYCLOAK-14063](https://issues.redhat.com/browse/KEYCLOAK-14063)

## Additional Information
Run new `e2e-local-image` Makefile target in a freshly built image deployed in the cluster. Previous `e2e-image` target has been renamed to `e2e-latest-image`.

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

## Additional Notes 
I had to add timeout settings for Travis because this target is taking longer. Some tests might fail, but I'm not sure if it is due to wrong deployment or the tests themselves. Please share your thoughts.