### PR TITLE
KEYCLOAK-14782 - Support of additional environment variables

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -154,6 +154,9 @@ spec:
               description: Name of the StorageClass for Postgresql Persistent Volume
                 Claim
               type: string
+            env:
+              description: Environment variables to add or overwrite the hard-coded
+              type: object
           type: object
         status:
           description: KeycloakStatus defines the observed state of Keycloak.

--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -154,8 +154,11 @@ spec:
               description: Name of the StorageClass for Postgresql Persistent Volume
                 Claim
               type: string
+            envFrom:
+              description: Config- or secretMaps for additional environment variables (does not overwrite the directly set environment variables)
+              type: object
             env:
-              description: Environment variables to add or overwrite the hard-coded
+              description: Environment variables to add or overwrite the hard-coded ones
               type: object
           type: object
         status:

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -65,6 +65,9 @@ type KeycloakSpec struct {
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
+	// Additional configmaps
+	EnvFrom []corev1.EnvFromSource `json:"envFrom,omitempty" protobuf:"bytes,19,rep,name=envFrom"`
+
 	// Additional environment variables to overwrite hardcoded ones
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -64,6 +64,9 @@ type KeycloakSpec struct {
 	// Name of the StorageClass for Postgresql Persistent Volume Claim
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
+	
+	// Additional environment variables to overwrite hardcoded ones
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 type DeploymentSpec struct {

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -64,7 +64,7 @@ type KeycloakSpec struct {
 	// Name of the StorageClass for Postgresql Persistent Volume Claim
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
-	
+
 	// Additional environment variables to overwrite hardcoded ones
 	Env []corev1.EnvVar `json:"env,omitempty"`
 }

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -159,11 +159,9 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 			Value: fmt.Sprintf("%v", GetExternalDatabasePort(dbSecret)),
 		})
 	}
-	
+
 	if len(cr.Spec.Env) > 0 {
-		for _, e := range cr.Spec.Env {
-			env = append(env, e)
-		}
+		env = append(env, cr.Spec.Env...)
 	}
 
 	return env

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -161,6 +161,13 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 	}
 
 	if len(cr.Spec.Env) > 0 {
+		for _, c := range cr.Spec.Env {
+			for index, e := range env {
+				if c.Name == e.Name {
+					env = append(env[:index], env[index+1:]...)
+				}
+			}
+		}
 		env = append(env, cr.Spec.Env...)
 	}
 
@@ -219,6 +226,7 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.Statefu
 							LivenessProbe:  livenessProbe(),
 							ReadinessProbe: readinessProbe(),
 							Env:            getKeycloakEnv(cr, dbSecret),
+							EnvFrom:        cr.Spec.EnvFrom,
 							Resources:      getResources(cr),
 						},
 					},

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -159,6 +159,12 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 			Value: fmt.Sprintf("%v", GetExternalDatabasePort(dbSecret)),
 		})
 	}
+	
+	if len(cr.Spec.Env) > 0 {
+		for _, e := range cr.Spec.Env {
+			env = append(env, e)
+		}
+	}
 
 	return env
 }


### PR DESCRIPTION
## JIRA ID
[KEYCLOAK-14782](https://issues.redhat.com/browse/KEYCLOAK-14782)
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->

## Additional Information
In the current version of the Keycloak Operator some environment variables are hardcoded. For example, CACHE_OWNER_COUNT.
I would like to have the possibility to select or overwrite these hardcoded variables myself and also to add other variables that might be used by own SPIs.

Therefore I have extended the Keycloak Spec with the possibility to add environment variables or configmaps.

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->