### PR TITLE
KEYCLOAK-14888 Create container build workflow for Quay

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,36 @@
+name: Container
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.asciidoc'
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - id: repository
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ github.repository }}
+
+      - name: Build and push container images
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+          repository: ${{ steps.repository.outputs.lowercase }}
+          registry: quay.io
+          tag_with_ref: true
+          always_pull: true
+          push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
When:

- a commit is pushed to any branch,
- or when a commit is tagged

build the Dockerfile located in the repo root, then push it to
https://quay.io/repository/keycloak/keycloak-operator