### PR TITLE
KEYCLOAK-14931: Remove `cluster.local` from DNS names in the deployment genertor.

### DIFF
--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -67,7 +67,7 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 		},
 		{
 			Name:  "DB_ADDR",
-			Value: PostgresqlServiceName + "." + cr.Namespace + ".svc.cluster.local",
+			Value: PostgresqlServiceName + "." + cr.Namespace,
 		},
 		{
 			Name:  "DB_DATABASE",
@@ -106,7 +106,7 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 		},
 		{
 			Name:  "JGROUPS_DISCOVERY_PROPERTIES",
-			Value: "dns_query=" + KeycloakDiscoveryServiceName + "." + cr.Namespace + ".svc.cluster.local",
+			Value: "dns_query=" + KeycloakDiscoveryServiceName + "." + cr.Namespace,
 		},
 		// Cache settings
 		{


### PR DESCRIPTION
Kube-DNS is configured with `ndots: 5`, which means that local names will be iteratively retried with five root names of the FQDN removed.

This fixes clusters that have DNS names other than `cluster.local`.

## Verification Steps

1. Create a cluster with a specific cluster name such as `c1.example.com`
1. Install Keycloak-Operator, notice operator generates a `Deployment` that has `cluster.local` in it's DNS names. These DNS names are incorrect and the deployment fails.
1. Apply patch and try again. `kube-dns` is configured with `ndots: 5`, which solves the problem.
