### PR TITLE
KEYCLOAK-16060 Hide vendor and generated files from GitHub diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+vendor/** linguist-generated=true
+**/zz_generated* linguist-generated=true


### PR DESCRIPTION
All files under the `vendor/` directory, and any file starting with `zz_generated` will be marked as a "generated" file, which GitHub will hide from diffs by default.

See [GitHub's documentation](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-how-changed-files-appear-on-github), [linguist-generated documentation](https://github.com/github/linguist/#generated-code), and [git pattern syntax](https://www.git-scm.com/docs/gitignore#_pattern_format).