### PR TITLE
KEYCLOAK-16079 Support Spec.TLS override in Keycloak Ingress

### DIFF
--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -46,7 +46,9 @@ func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
 func KeycloakIngressReconciled(cr *kc.Keycloak, currentState *v1beta1.Ingress) *v1beta1.Ingress {
 	reconciled := currentState.DeepCopy()
 	reconciledHost := currentState.Spec.Rules[0].Host
+	reconciledSpecTLS := currentState.Spec.TLS
 	reconciled.Spec = v1beta1.IngressSpec{
+		TLS: reconciledSpecTLS,
 		Rules: []v1beta1.IngressRule{
 			{
 				Host: reconciledHost,

--- a/pkg/model/keycloak_ingress_test.go
+++ b/pkg/model/keycloak_ingress_test.go
@@ -1,0 +1,46 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/api/extensions/v1beta1"
+)
+
+func TestKeycloakIngress_testTLSOverride(t *testing.T) {
+	//given
+	currentState := &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts: []string{
+						IngressDefaultHost,
+					},
+					SecretName: "keycloak-secret",
+				},
+			},
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: IngressDefaultHost,
+				},
+			},
+		},
+	}
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	reconciledIngress := KeycloakIngressReconciled(cr, currentState)
+
+	//then
+	assert.Equal(t, 1, len(reconciledIngress.Spec.TLS))
+	assert.Equal(t, 1, len(reconciledIngress.Spec.TLS[0].Hosts))
+	assert.Equal(t, IngressDefaultHost, reconciledIngress.Spec.TLS[0].Hosts[0])
+	assert.Equal(t, "keycloak-secret", reconciledIngress.Spec.TLS[0].SecretName)
+}


### PR DESCRIPTION
Support Spec.TLS override made in Keycloak Ingress after it is originally created. This will help to use keycloak ingress with
other ingress controller deployed in the cluster. It works same way as Spec.Rules[0].Host override is implemented.

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-16079

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->