### PR TITLE
KEYCLOAK-16102 Update client secret on change in KeycloakClient CR

### DIFF
--- a/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
+++ b/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
@@ -52,6 +52,8 @@ func TestKeycloakClientReconciler_Test_Creating_Client(t *testing.T) {
 	assert.IsType(t, common.CreateClientAction{}, desiredState[1])
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[2])
 	assert.IsType(t, model.ClientSecret(cr), desiredState[2].(common.GenericCreateAction).Ref)
+	assert.Equal(t, []byte("test"), model.ClientSecret(cr).Data[model.ClientSecretClientIDProperty])
+	assert.Equal(t, []byte("test"), model.ClientSecret(cr).Data[model.ClientSecretClientSecretProperty])
 }
 
 func TestKeycloakClientReconciler_Test_PartialUpdate_Client(t *testing.T) {
@@ -97,6 +99,8 @@ func TestKeycloakClientReconciler_Test_PartialUpdate_Client(t *testing.T) {
 	// client secret still needs to be created even if the client exists
 	assert.IsType(t, common.GenericCreateAction{}, desiredState[2])
 	assert.IsType(t, model.ClientSecret(cr), desiredState[2].(common.GenericCreateAction).Ref)
+	assert.Equal(t, []byte("test"), model.ClientSecret(cr).Data[model.ClientSecretClientIDProperty])
+	assert.Equal(t, []byte("test"), model.ClientSecret(cr).Data[model.ClientSecretClientSecretProperty])
 }
 
 func TestKeycloakClientReconciler_Test_Delete_Client(t *testing.T) {
@@ -181,6 +185,8 @@ func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 	assert.Equal(t, "test", desiredState[1].(common.UpdateClientAction).Realm)
 	assert.IsType(t, common.GenericUpdateAction{}, desiredState[2])
 	assert.IsType(t, model.ClientSecretReconciled(cr, currentState.ClientSecret), desiredState[2].(common.GenericUpdateAction).Ref)
+	assert.Equal(t, []byte("test"), model.ClientSecretReconciled(cr, currentState.ClientSecret).Data[model.ClientSecretClientIDProperty])
+	assert.Equal(t, []byte("test"), model.ClientSecretReconciled(cr, currentState.ClientSecret).Data[model.ClientSecretClientSecretProperty])
 }
 
 func TestKeycloakClientReconciler_Test_Marshal_Client(t *testing.T) {

--- a/pkg/model/client_secret.go
+++ b/pkg/model/client_secret.go
@@ -37,6 +37,5 @@ func ClientSecretReconciled(cr *v1alpha1.KeycloakClient, currentState *v1.Secret
 		ClientSecretClientIDProperty:     []byte(cr.Spec.Client.ClientID),
 		ClientSecretClientSecretProperty: []byte(cr.Spec.Client.Secret),
 	}
-	reconciled.Data = map[string][]byte{}
 	return reconciled
 }


### PR DESCRIPTION
This fix will update client secret in kubernetes Secret and
keycloak when KeycloakClient CR is updated with new client secret
in Spec instead of resetting back to what is saved in keycloak

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-16102

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->