### PR TITLE
KEYCLOAK-15109 Ingress/Route Host Override

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -59,6 +59,10 @@ spec:
                   description: If set to true, the Operator will create an Ingress
                     or a Route pointing to Keycloak.
                   type: boolean
+                host:
+                  description: If set, the Operator will use value of host for Ingress
+                    host instead of default value keycloak.local
+                  type: string
                 tlsTermination:
                   description: TLS Termination type for the external access. Setting
                     this field to "reencrypt" will terminate TLS on the Ingress/Route

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -161,6 +161,11 @@ type KeycloakExternalAccess struct {
 	// Ingress TLS configuration is the same in both cases and it is up to the user
 	// to configure TLS section of the Ingress.
 	TLSTermination TLSTerminationType `json:"tlsTermination,omitempty"`
+	// If set, the Operator will use value of host for Ingress/Route host
+	// instead of default value keycloak.local for ingress and automatically
+	// chosen name for Route
+	// +optional
+	Host string `json:"host,omitempty"`
 }
 
 type KeycloakExternalDatabase struct {

--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -9,6 +9,11 @@ import (
 )
 
 func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
+	ingressHost := cr.Spec.ExternalAccess.Host
+	if ingressHost == "" {
+		ingressHost = IngressDefaultHost
+	}
+
 	return &v1beta1.Ingress{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      ApplicationName,
@@ -23,7 +28,7 @@ func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{
 				{
-					Host: IngressDefaultHost,
+					Host: ingressHost,
 					IngressRuleValue: v1beta1.IngressRuleValue{
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{

--- a/pkg/model/keycloak_ingress_test.go
+++ b/pkg/model/keycloak_ingress_test.go
@@ -44,3 +44,91 @@ func TestKeycloakIngress_testTLSOverride(t *testing.T) {
 	assert.Equal(t, IngressDefaultHost, reconciledIngress.Spec.TLS[0].Hosts[0])
 	assert.Equal(t, "keycloak-secret", reconciledIngress.Spec.TLS[0].SecretName)
 }
+
+func TestKeycloakIngress_testHost(t *testing.T) {
+	//given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	ingress := KeycloakIngress(cr)
+
+	//then
+	assert.Equal(t, IngressDefaultHost, ingress.Spec.Rules[0].Host)
+}
+
+func TestKeycloakIngress_testHostReconciled(t *testing.T) {
+	//given
+	currentState := &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: IngressDefaultHost,
+				},
+			},
+		},
+	}
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	reconciledIngress := KeycloakIngressReconciled(cr, currentState)
+
+	//then
+	assert.Equal(t, IngressDefaultHost, reconciledIngress.Spec.Rules[0].Host)
+}
+
+func TestKeycloakIngress_testHostOverride(t *testing.T) {
+	//given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+				Host:    "host-override",
+			},
+		},
+	}
+
+	//when
+	ingress := KeycloakIngress(cr)
+
+	//then
+	assert.Equal(t, "host-override", ingress.Spec.Rules[0].Host)
+}
+
+func TestKeycloakIngress_testHostOverrideReconciled(t *testing.T) {
+	//given
+	currentState := &v1beta1.Ingress{
+		Spec: v1beta1.IngressSpec{
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: "host-override",
+				},
+			},
+		},
+	}
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+				Host:    "host-override",
+			},
+		},
+	}
+
+	//when
+	reconciledIngress := KeycloakIngressReconciled(cr, currentState)
+
+	//then
+	assert.Equal(t, "host-override", reconciledIngress.Spec.Rules[0].Host)
+}

--- a/pkg/model/keycloak_route.go
+++ b/pkg/model/keycloak_route.go
@@ -21,6 +21,7 @@ func KeycloakRoute(cr *kc.Keycloak) *v1.Route {
 			},
 		},
 		Spec: v1.RouteSpec{
+			Host: cr.Spec.ExternalAccess.Host,
 			Port: &v1.RoutePort{
 				TargetPort: intstr.FromString(ApplicationName),
 			},
@@ -38,6 +39,7 @@ func KeycloakRoute(cr *kc.Keycloak) *v1.Route {
 func KeycloakRouteReconciled(cr *kc.Keycloak, currentState *v1.Route) *v1.Route {
 	reconciled := currentState.DeepCopy()
 	reconciled.Spec = v1.RouteSpec{
+		Host: cr.Spec.ExternalAccess.Host,
 		Port: &v1.RoutePort{
 			TargetPort: intstr.FromString(ApplicationName),
 		},

--- a/pkg/model/keycloak_route_test.go
+++ b/pkg/model/keycloak_route_test.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	v1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeycloakRoute_testHost(t *testing.T) {
+	//given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	route := KeycloakRoute(cr)
+
+	//then
+	assert.Equal(t, "", route.Spec.Host)
+}
+
+func TestKeycloakRoute_testHostReconciled(t *testing.T) {
+	//given
+	currentState := &v1.Route{
+		Spec: v1.RouteSpec{},
+	}
+
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	reconciledRoute := KeycloakRouteReconciled(cr, currentState)
+
+	//then
+	assert.Equal(t, "", reconciledRoute.Spec.Host)
+}
+
+func TestKeycloakRoute_testHostOverride(t *testing.T) {
+	//given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+				Host:    "host-override",
+			},
+		},
+	}
+
+	//when
+	route := KeycloakRoute(cr)
+
+	//then
+	assert.Equal(t, "host-override", route.Spec.Host)
+}
+
+func TestKeycloakRoute_testHostOverrideReconciled(t *testing.T) {
+	//given
+	currentState := &v1.Route{
+		Spec: v1.RouteSpec{},
+	}
+
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+				Host:    "host-override",
+			},
+		},
+	}
+
+	//when
+	reconciledRoute := KeycloakRouteReconciled(cr, currentState)
+
+	//then
+	assert.Equal(t, "host-override", reconciledRoute.Spec.Host)
+}


### PR DESCRIPTION
Support overriding default host set in Ingress/Route through Keycloak CR

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-15109

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->