### PR TITLE
[KEYCLOAK-16368] CI is broken due to some changes on GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,30 +18,15 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: Unit tests
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        make test/unit test/goveralls
-    - name: Start minikube
-      id: minikube
-      env:
-        CHANGE_MINIKUBE_NONE_USER: true
-        MINIKUBE_WANTUPDATENOTIFICATION: false
-        MINIKUBE_WANTREPORTERRORPROMPT: false
-      uses: medyagh/setup-minikube@master
-    - name: Setup minikube
-      run: |
-        sudo ./hack/modify_etc_hosts.sh "keycloak.local"
-        minikube addons enable ingress
+        make test/unit
     - name: Run e2e tests
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
+        make setup/github
+        sudo chown -R $USER $HOME/.kube $HOME/.minikube
         make cluster/prepare 
-        make test/e2e test/goveralls
+        make test/e2e
     - name: Run e2e tests for local image
-      env:
-        COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         make test/e2e-local-image
     - name: After failure

--- a/Makefile
+++ b/Makefile
@@ -157,8 +157,8 @@ code/lint:
 ##############################
 # CI                         #
 ##############################
-.PHONY: setup/travis
-setup/travis:
+.PHONY: setup/github
+setup/github:
 	@echo Installing Kubectl
 	@curl -Lo kubectl ${KUBECTL_DOWNLOAD_URL} && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 	@echo Installing Minikube
@@ -167,8 +167,7 @@ setup/travis:
 	@mkdir -p $HOME/.kube $HOME/.minikube
 	@touch $KUBECONFIG
 	@sudo minikube start --vm-driver=none
-	@sudo chown -R travis: /home/travis/.minikube/
-	sudo ./hack/modify_etc_hosts.sh "keycloak.local"
+	@sudo ./hack/modify_etc_hosts.sh "keycloak.local"
 	@sudo minikube addons enable ingress
 
 .PHONY: test/goveralls


### PR DESCRIPTION
## [KEYCLOAK-16368](https://issues.redhat.com/browse/KEYCLOAK-16368)

Replaces the usage of [medyagh/setup-minikube@master](https://github.com/medyagh/setup-minikube)

## Additional Information

Unfortunately, the GitHub actions for Minikube still use `add-path` which is deprecated by GitHub and no longer functional. We tried to submit [a pull-request](https://github.com/medyagh/setup-minikube/pull/13) to the author, but we didn't hear anything back until now.

Considering that this is critical, I'd suggest to include the changes in this PR.

## Additional Notes 

* `ACTIONS_ALLOW_UNSECURE_COMMANDS` solves the issue, but it is unsafe.
* Coveralls was intentionally removed as it was already broken a while ago. We may revisit it in the future, but not a priority for now.
* Supersedes #271 