### PR TITLE
Add list podmonitors to role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -72,6 +72,7 @@ rules:
   resources:
   - servicemonitors
   - prometheusrules
+  - podmonitors
   verbs:
   - list
   - get


### PR DESCRIPTION
The operator needs to have permission to list podmonitors for the monitoring.coreos.com api.