### PR TITLE
[KEYCLOAK-16551] Remove references to Gatekeeper in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ Before contributing to Keycloak Operator please read our [contributing guideline
 * [Keycloak Documentation](https://github.com/keycloak/keycloak-documentation) - Documentation for Keycloak
 * [Keycloak QuickStarts](https://github.com/keycloak/keycloak-quickstarts) - QuickStarts for getting started with Keycloak
 * [Keycloak Docker](https://github.com/jboss-dockerfiles/keycloak) - Docker images for Keycloak
-* [Keycloak Gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) - Proxy service to secure apps and services with Keycloak
 * [Keycloak Node.js Connect](https://github.com/keycloak/keycloak-nodejs-connect) - Node.js adapter for Keycloak
 * [Keycloak Node.js Admin Client](https://github.com/keycloak/keycloak-nodejs-admin-client) - Node.js library for Keycloak Admin REST API
 


### PR DESCRIPTION
Gatekeeper is EOL and no longer make sense to list it.