### PR TITLE
Fix fullScopeAllowed in client CRD

### DIFF
--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -93,7 +93,7 @@ type KeycloakAPIClient struct {
 	Attributes map[string]string `json:"attributes,omitempty"`
 	// True if Full Scope is allowed.
 	// +optional
-	FullScopeAllowed bool `json:"fullScopeAllowed,omitempty"`
+	FullScopeAllowed *bool `json:"fullScopeAllowed,omitempty"`
 	// Node registration timeout.
 	// +optional
 	NodeReRegistrationTimeout int `json:"nodeReRegistrationTimeout,omitempty"`

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -273,6 +273,11 @@ func (in *KeycloakAPIClient) DeepCopyInto(out *KeycloakAPIClient) {
 			(*out)[key] = val
 		}
 	}
+	if in.FullScopeAllowed != nil {
+		in, out := &in.FullScopeAllowed, &out.FullScopeAllowed
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ProtocolMappers != nil {
 		in, out := &in.ProtocolMappers, &out.ProtocolMappers
 		*out = make([]KeycloakProtocolMapper, len(*in))

--- a/test/e2e/keycloak_client_test.go
+++ b/test/e2e/keycloak_client_test.go
@@ -78,7 +78,7 @@ func getKeycloakClientCR(namespace string, external bool) *keycloakv1alpha1.Keyc
 				PublicClient:              true,
 				FrontchannelLogout:        false,
 				Protocol:                  "openid-connect",
-				FullScopeAllowed:          true,
+				FullScopeAllowed:          &[]bool{true}[0],
 				NodeReRegistrationTimeout: -1,
 				DefaultClientScopes:       []string{"profile"},
 				OptionalClientScopes:      []string{"microprofile-jwt"},


### PR DESCRIPTION
Since the default is true we can only express unset/false/true with a *bool.

See this discussion https://github.com/keycloak/keycloak-operator/pull/121#discussion_r368417642