### PR TITLE
[WIP] KEYCLOAK-16406. Hide metrics endpoint in Ingress.

### DIFF
--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -23,6 +23,11 @@ func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
 			},
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
+				"nginx.ingress.kubernetes.io/server-snippet": `
+                      location ~* "^/auth/realms/master/metrics" {
+                          deny all;
+                          return 404;
+                        }`,
 			},
 		},
 		Spec: v1beta1.IngressSpec{

--- a/test/e2e/keycloaks_test.go
+++ b/test/e2e/keycloaks_test.go
@@ -189,7 +189,15 @@ func keycloakDeploymentTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	err = WaitForSuccessResponse(t, f, keycloakInternalURL+"/auth/realms/master/metrics")
+	response, err := http.Get(keycloakInternalURL + "/auth/realms/master/metrics")
+	response.Body.Close()
+	if err == nil && response.StatusCode != 404 {
+		return errors.Errorf("invalid response for Keycloak metrics (%v)", response.Status)
+	}
+	if response.StatusCode == 404 {
+		return nil
+	}
+
 	return err
 }
 


### PR DESCRIPTION
This change hides the `/metrics` endpoint from outside the cluster in the Ingress router.

**DO NOT MERGE YET.**