### PR TITLE
KEYCLOAK-16766 Bump backup-container image to latest 1.0.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please remember to provide a good summary, description as well as steps to repro
 ### Creating Keycloak Instance
 Once the CRDs and RBAC rules are applied and the operator is running. Use the examples from the operator.
 
-1. Run `kubectl apply -f deploy/examples/keycloak/keycloak.yaml` 
+1. Run `kubectl apply -f deploy/examples/keycloak/keycloak.yaml`
 
 ## Building from Source
 
@@ -99,7 +99,7 @@ Debug the operator in [VS Code](https://code.visualstudio.com/docs/languages/go)
   "args": []
 }
 ```
-3. Debug Keycloak Operator 
+3. Debug Keycloak Operator
 
 #### Alternative Step 3: Deploying to a Cluster
 Deploy the operator into the running cluster
@@ -181,7 +181,7 @@ All images used by the Operator might be controlled using dedicated Environmenta
  | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                |
- | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.10`                    |
+ | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                    |
  | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
 
 ## Contributing

--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -20,7 +20,7 @@ const (
 	DefaultRHSSOImageOpenJDK     = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4"
 	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:master"
 	DefaultRHSSOInitContainer    = "registry.redhat.io/rh-sso-7-tech-preview/sso74-init-container-rhel8:7.4"
-	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.14"
+	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.16"
 	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"
 )
 


### PR DESCRIPTION
## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
https://issues.redhat.com/browse/KEYCLOAK-16766

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

A new version of the backup-container image has been published. There are no changes that affect the Keycloak operator's usage of it, so this is mostly just a respin on top of an updated base image.

https://quay.io/repository/integreatly/backup-container?tab=tags

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->