### PR TITLE
Use a init container to set PVC permissions

### DIFF
--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -62,6 +63,26 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak) *v13.Deployment {
 					},
 				},
 				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						{
+							Name:  "init-pvc",
+							Image: Images.Images[PostgresqlImage],
+							SecurityContext: &v1.SecurityContext{
+								RunAsUser: pointer.Int64Ptr(0),
+							},
+							Command: []string{
+								"sh",
+								"-c",
+								"chown -R postgres:postgres " + PostgresqlPersistentVolumeMountPath,
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      PostgresqlPersistentVolumeName,
+									MountPath: PostgresqlPersistentVolumeMountPath,
+								},
+							},
+						},
+					},
 					Containers: []v1.Container{
 						{
 							Name:  PostgresqlDeploymentName,


### PR DESCRIPTION
Launch a init container to fix permissions on PVC.
Fix a problem when launching a Keycloak instance with aws-ebs disk

## JIRA ID

https://issues.redhat.com/browse/KEYCLOAK-16730

## Additional Information

I'm using the Keycloak operator with a Kops cluster deployed in AWS. When I try to deploy a Keycloak instance, the Postgresql instance fail to start with a problem on disk default owner (root).

The only way to fix the problem is to mount this persistent volume, set the owner to postgres (group postgres) and let the postgres container start.

## Verification Steps

- Create a Kops cluster with aws-ebs storage class
- Launch the operator
- Generate a Keycloak instance
- After a few seconds/minutes the Keycloak postgres must be started

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)
