### PR TITLE
fix(alerts): remove the KeycloakJavaNonHeapThresholdExceeded alert

### DIFF
--- a/pkg/model/prometheus_rule.go
+++ b/pkg/model/prometheus_rule.go
@@ -10,16 +10,6 @@ import (
 
 func PrometheusRule(cr *v1alpha1.Keycloak) *monitoringv1.PrometheusRule {
 	rules := []monitoringv1.Rule{{
-		Alert: "KeycloakJavaHeapThresholdExceeded",
-		Annotations: map[string]string{
-			"message": `{{ printf "%0.0f" $value }}% heap usage of {{ $labels.area }} in pod {{$labels.pod }}, namespace {{ $labels.namespace }}.`,
-		},
-		Expr: intstr.FromString(`100 * jvm_memory_bytes_used{area="heap",namespace="` + cr.Namespace + `"} / jvm_memory_bytes_max{area="heap",namespace="` + cr.Namespace + `"} > 90`),
-		For:  "1m",
-		Labels: map[string]string{
-			"severity": "warning",
-		},
-	}, {
 		Alert: "KeycloakJavaNonHeapThresholdExceeded",
 		Annotations: map[string]string{
 			"message": `{{ printf "%0.0f" $value }}% nonheap usage of {{ $labels.area }} in pod {{ $labels.pod }}, namespace {{ $labels.namespace }}.`,


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-16751

## Additional Information

There is no action that SRE can take when this alert is firing, and in prod environment it has been fired a lot and generated a lot of false positives.

Another option could be we can increase the time for which the alert will be generated. But again, when the alert is fired, there is no action that SRE can take to solve the issue.

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)
