### PR TITLE
Check route readiness only if ExternalAccess is enabled

### DIFF
--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -483,10 +483,12 @@ func (i *ClusterState) IsResourcesReady(cr *kc.Keycloak) (bool, error) {
 	}
 
 	// If running on OpenShift, check the Route is ready
-	stateManager := GetStateManager()
-	openshift, keyExists := stateManager.GetState(RouteKind).(bool)
-	if keyExists && openshift {
-		keycloakRouteReady = IsRouteReady(i.KeycloakRoute)
+	if cr.Spec.ExternalAccess.Enabled {
+		stateManager := GetStateManager()
+		openshift, keyExists := stateManager.GetState(RouteKind).(bool)
+		if keyExists && openshift {
+			keycloakRouteReady = IsRouteReady(i.KeycloakRoute)
+		}
 	}
 
 	return keycloakDeploymentReady && postgresqlDeploymentReady && keycloakRouteReady, nil

--- a/pkg/common/cluster_state_test.go
+++ b/pkg/common/cluster_state_test.go
@@ -1,0 +1,107 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestIsResourcesReady_Test_Route_Disabled_(t *testing.T) {
+	// given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: false,
+			},
+		},
+	}
+	clusterState := prepareTestingClusterState()
+
+	// when
+	GetStateManager().SetState(RouteKind, true)
+	ready, err := clusterState.IsResourcesReady(cr)
+
+	// then
+	assert.Nil(t, err)
+	assert.Equal(t, true, ready)
+}
+
+func TestIsResourcesReady_Test_Route_Enabled_(t *testing.T) {
+	// given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+	clusterState := prepareTestingClusterState()
+
+	// when
+	GetStateManager().SetState(RouteKind, true)
+	ready, err := clusterState.IsResourcesReady(cr)
+
+	// then
+	assert.Nil(t, err)
+	assert.Equal(t, false, ready)
+}
+func TestIsResourcesReady_Test_Route_Enabled_Exists_(t *testing.T) {
+	// given
+	cr := &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalAccess: v1alpha1.KeycloakExternalAccess{
+				Enabled: true,
+			},
+		},
+	}
+	clusterState := prepareTestingClusterState()
+	clusterState.KeycloakRoute = &routev1.Route{
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Conditions: []routev1.RouteIngressCondition{
+						{
+							Type:   routev1.RouteAdmitted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// when
+	GetStateManager().SetState(RouteKind, true)
+	ready, err := clusterState.IsResourcesReady(cr)
+
+	// then
+	assert.Nil(t, err)
+	assert.Equal(t, true, ready)
+}
+
+func prepareTestingClusterState() *ClusterState {
+	clusterState := NewClusterState()
+
+	var replicas int32 = 3
+	clusterState.KeycloakDeployment = &appsv1.StatefulSet{
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.StatefulSetStatus{
+			Replicas:        replicas,
+			ReadyReplicas:   replicas,
+			CurrentRevision: "1",
+			UpdateRevision:  "1",
+		},
+	}
+	clusterState.PostgresqlDeployment = &appsv1.Deployment{
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{},
+		},
+	}
+	return clusterState
+}


### PR DESCRIPTION
## JIRA
https://issues.redhat.com/browse/KEYCLOAK-16771

## Additional Information
*What:*
On OpenShift, Keycloak CR will be stuck with `status.ready = false` if `.spec.ExternalAccess.enable = false`

*Why:*
Keycloak Operator should not be waiting for the route to become ready if the route is disabled via Keycloak CR spec.


## Verification Steps
1. Install the operator on a testing Openshift cluster (or run it locally against a namespace on Openshift cluster)
2. Create a valid Keycloak CR with `.spec.ExternalAccess.enable = false`
3. After keycloak StatefulSet and postgres deployment become ready, `.status.ready` field of the CR should become `true` 

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->