### PR TITLE
Fix for postgres deployment CR for openshift

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
+	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
 	sigs.k8s.io/controller-runtime v0.6.0
 
 )

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	k8s.io/apimachinery v0.18.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
-	k8s.io/utils v0.0.0-20200414100711-2df71ebbae66
 	sigs.k8s.io/controller-runtime v0.6.0
 
 )

--- a/pkg/common/auto_detect.go
+++ b/pkg/common/auto_detect.go
@@ -54,6 +54,7 @@ func (b *Background) Stop() {
 }
 
 func (b *Background) autoDetectCapabilities() {
+	b.detectOpenshift()
 	b.detectMonitoringResources()
 	b.detectRoute()
 }
@@ -86,5 +87,18 @@ func (b *Background) detectMonitoringResources() {
 	resourceExists, _ = k8sutil.ResourceExists(b.dc, grafanav1alpha1.SchemeGroupVersion.String(), grafanav1alpha1.GrafanaDashboardKind)
 	if resourceExists {
 		b.SubscriptionChannel <- grafanav1alpha1.SchemeGroupVersion.WithKind(grafanav1alpha1.GrafanaDashboardKind)
+	}
+}
+
+func (b *Background) detectOpenshift() {
+	apiGroupVersion := "operator.openshift.io/v1"
+	kind := OpenShiftAPIServerKind
+	stateManager := GetStateManager()
+	isOpenshift, _ := k8sutil.ResourceExists(b.dc, apiGroupVersion, kind)
+	if isOpenshift {
+		// Set state that its Openshift (helps to differentiate between openshift and kubernetes)
+		stateManager.SetState(OpenShiftAPIServerKind, true)
+	} else {
+		stateManager.SetState(OpenShiftAPIServerKind, false)
 	}
 }

--- a/pkg/common/cluster_state.go
+++ b/pkg/common/cluster_state.go
@@ -233,7 +233,11 @@ func (i *ClusterState) readPostgresqlServiceEndpointsCurrentState(context contex
 }
 
 func (i *ClusterState) readPostgresqlDeploymentCurrentState(context context.Context, cr *kc.Keycloak, controllerClient client.Client) error {
-	postgresqlDeployment := model.PostgresqlDeployment(cr)
+	// Find out if we're on OpenShift or Kubernetes
+	stateManager := GetStateManager()
+	isOpenshift, _ := stateManager.GetState(OpenShiftAPIServerKind).(bool)
+
+	postgresqlDeployment := model.PostgresqlDeployment(cr, isOpenshift)
 	postgresqlDeploymentSelector := model.PostgresqlDeploymentSelector(cr)
 
 	err := controllerClient.Get(context, postgresqlDeploymentSelector, postgresqlDeployment)

--- a/pkg/common/controller_utils.go
+++ b/pkg/common/controller_utils.go
@@ -25,6 +25,7 @@ const (
 	DeploymentKind            = "Deployment"
 	PersistentVolumeClaimKind = "PersistentVolumeClaim"
 	PodDisruptionBudgetKind   = "PodDisruptionBudget"
+	OpenShiftAPIServerKind    = "OpenShiftAPIServer"
 )
 
 func WatchSecondaryResource(c controller.Controller, controllerName string, resourceKind string, objectTypetoWatch runtime.Object, cr runtime.Object) error {

--- a/pkg/controller/keycloak/keycloak_reconciler.go
+++ b/pkg/controller/keycloak/keycloak_reconciler.go
@@ -77,7 +77,7 @@ func (i *KeycloakReconciler) reconcileExternalAccess(desired *common.DesiredClus
 	// Find out if we're on OpenShift or Kubernetes and create either a Route or
 	// an Ingress
 	stateManager := common.GetStateManager()
-	openshift, keyExists := stateManager.GetState(common.RouteKind).(bool)
+	openshift, keyExists := stateManager.GetState(common.OpenShiftAPIServerKind).(bool)
 
 	if keyExists && openshift {
 		desired.AddAction(i.getKeycloakRouteDesiredState(clusterState, cr))
@@ -142,7 +142,12 @@ func (i *KeycloakReconciler) getPostgresqlServiceDesiredState(clusterState *comm
 }
 
 func (i *KeycloakReconciler) getPostgresqlDeploymentDesiredState(clusterState *common.ClusterState, cr *kc.Keycloak) common.ClusterAction {
-	postgresqlDeployment := model.PostgresqlDeployment(cr)
+	// Find out if we're on OpenShift or Kubernetes
+	stateManager := common.GetStateManager()
+	isOpenshift, _ := stateManager.GetState(common.OpenShiftAPIServerKind).(bool)
+
+	postgresqlDeployment := model.PostgresqlDeployment(cr, isOpenshift)
+
 	if clusterState.PostgresqlDeployment == nil {
 		return common.GenericCreateAction{
 			Ref: postgresqlDeployment,

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -36,6 +36,7 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	stateManager.SetState(common.GetStateFieldName(ControllerName, monitoringv1.ServiceMonitorsKind), true)
 	stateManager.SetState(common.GetStateFieldName(ControllerName, grafanav1alpha1.GrafanaDashboardKind), true)
 	stateManager.SetState(common.RouteKind, true)
+	stateManager.SetState(common.OpenShiftAPIServerKind, true)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -76,7 +77,7 @@ func TestKeycloakReconciler_Test_Creating_All(t *testing.T) {
 	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[3].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericCreateAction).Ref)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr, true), desiredState[6].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.PostgresqlService(cr, model.DatabaseSecret(cr), false), desiredState[7].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericCreateAction).Ref)
@@ -140,7 +141,7 @@ func TestKeycloakReconciler_Test_Updating_RHSSO(t *testing.T) {
 		DatabaseSecret:                  model.DatabaseSecret(cr),
 		PostgresqlPersistentVolumeClaim: model.PostgresqlPersistentVolumeClaim(cr),
 		PostgresqlService:               model.PostgresqlService(cr, model.DatabaseSecret(cr), false),
-		PostgresqlDeployment:            model.PostgresqlDeployment(cr),
+		PostgresqlDeployment:            model.PostgresqlDeployment(cr, true),
 		KeycloakService:                 model.KeycloakService(cr),
 		KeycloakDiscoveryService:        model.KeycloakDiscoveryService(cr),
 		KeycloakDeployment:              model.RHSSODeployment(cr, model.DatabaseSecret(cr)),
@@ -183,7 +184,7 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 		DatabaseSecret:                  model.DatabaseSecret(cr),
 		PostgresqlPersistentVolumeClaim: model.PostgresqlPersistentVolumeClaim(cr),
 		PostgresqlService:               model.PostgresqlService(cr, model.DatabaseSecret(cr), false),
-		PostgresqlDeployment:            model.PostgresqlDeployment(cr),
+		PostgresqlDeployment:            model.PostgresqlDeployment(cr, true),
 		KeycloakService:                 model.KeycloakService(cr),
 		KeycloakDiscoveryService:        model.KeycloakDiscoveryService(cr),
 		KeycloakDeployment:              model.KeycloakDeployment(cr, model.DatabaseSecret(cr)),
@@ -198,6 +199,7 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 	stateManager.SetState(common.GetStateFieldName(ControllerName, monitoringv1.ServiceMonitorsKind), true)
 	stateManager.SetState(common.GetStateFieldName(ControllerName, grafanav1alpha1.GrafanaDashboardKind), true)
 	stateManager.SetState(common.RouteKind, true)
+	stateManager.SetState(common.OpenShiftAPIServerKind, true)
 	defer stateManager.Clear()
 
 	// when
@@ -237,7 +239,7 @@ func TestKeycloakReconciler_Test_Updating_All(t *testing.T) {
 	assert.IsType(t, model.GrafanaDashboard(cr), desiredState[3].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.DatabaseSecret(cr), desiredState[4].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.PostgresqlPersistentVolumeClaim(cr), desiredState[5].(common.GenericUpdateAction).Ref)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericUpdateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr, true), desiredState[6].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.PostgresqlService(cr, model.DatabaseSecret(cr), false), desiredState[7].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.KeycloakService(cr), desiredState[8].(common.GenericUpdateAction).Ref)
 	assert.IsType(t, model.KeycloakDiscoveryService(cr), desiredState[9].(common.GenericUpdateAction).Ref)
@@ -581,6 +583,7 @@ func TestKeycloakReconciler_Test_Setting_Resources(t *testing.T) {
 	stateManager.SetState(common.GetStateFieldName(ControllerName, monitoringv1.ServiceMonitorsKind), true)
 	stateManager.SetState(common.GetStateFieldName(ControllerName, grafanav1alpha1.GrafanaDashboardKind), true)
 	stateManager.SetState(common.RouteKind, true)
+	stateManager.SetState(common.OpenShiftAPIServerKind, false)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -590,7 +593,7 @@ func TestKeycloakReconciler_Test_Setting_Resources(t *testing.T) {
 	//    6) Postgresql Deployment
 	//    11) Keycloak StatefulSets
 	assert.Equal(t, len(desiredState), 13)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr, false), desiredState[6].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDeployment(cr, model.DatabaseSecret(cr)), desiredState[11].(common.GenericCreateAction).Ref)
 	keycloakContainer := desiredState[11].(common.GenericCreateAction).Ref.(*v13.StatefulSet).Spec.Template.Spec.Containers[0]
 	assert.Equal(t, &resource700Mi, keycloakContainer.Resources.Requests.Memory(), "Keycloak Deployment: Memory-Requests should be: "+resource700Mi.String()+" but is "+keycloakContainer.Resources.Requests.Memory().String())
@@ -619,6 +622,7 @@ func TestKeycloakReconciler_Test_No_Resources_Specified(t *testing.T) {
 	stateManager.SetState(common.GetStateFieldName(ControllerName, monitoringv1.ServiceMonitorsKind), true)
 	stateManager.SetState(common.GetStateFieldName(ControllerName, grafanav1alpha1.GrafanaDashboardKind), true)
 	stateManager.SetState(common.RouteKind, true)
+	stateManager.SetState(common.OpenShiftAPIServerKind, true)
 
 	// when
 	reconciler := NewKeycloakReconciler()
@@ -628,7 +632,7 @@ func TestKeycloakReconciler_Test_No_Resources_Specified(t *testing.T) {
 	//    6) Postgresql Deployment
 	//    11) Keycloak StatefulSets
 	assert.Equal(t, len(desiredState), 13)
-	assert.IsType(t, model.PostgresqlDeployment(cr), desiredState[6].(common.GenericCreateAction).Ref)
+	assert.IsType(t, model.PostgresqlDeployment(cr, true), desiredState[6].(common.GenericCreateAction).Ref)
 	assert.IsType(t, model.KeycloakDeployment(cr, model.DatabaseSecret(cr)), desiredState[11].(common.GenericCreateAction).Ref)
 	keycloakContainer := desiredState[11].(common.GenericCreateAction).Ref.(*v13.StatefulSet).Spec.Template.Spec.Containers[0]
 	assert.Equal(t, 0, len(keycloakContainer.Resources.Requests), "Requests-List should be empty")

--- a/pkg/controller/keycloak/keycloak_reconciler_test.go
+++ b/pkg/controller/keycloak/keycloak_reconciler_test.go
@@ -583,7 +583,6 @@ func TestKeycloakReconciler_Test_Setting_Resources(t *testing.T) {
 	stateManager.SetState(common.GetStateFieldName(ControllerName, monitoringv1.ServiceMonitorsKind), true)
 	stateManager.SetState(common.GetStateFieldName(ControllerName, grafanav1alpha1.GrafanaDashboardKind), true)
 	stateManager.SetState(common.RouteKind, true)
-	stateManager.SetState(common.OpenShiftAPIServerKind, false)
 
 	// when
 	reconciler := NewKeycloakReconciler()

--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -150,7 +150,6 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak, isOpenshift bool) *v13.Deployme
 		},
 	}
 
-	//If not openshift append the initcontainer part
 	if !isOpenshift {
 		v13Deployment.Spec.Template.Spec.InitContainers = getPostgresqlDeploymentInitContainer(cr)
 	}


### PR DESCRIPTION
## JIRA ID
 https://issues.redhat.com/browse/KEYCLOAK-16864

## Additional Information
Init containers change that was added would work only
with plain Kubernetes. Code changes made to detect if
the underlying cluster is openshift or Kubernetes and then to add the init containers
part based on that.

## Verification Steps
> create either openshift or kuberntes cluster
> run the operator 
   Follow steps here: https://github.com/keycloak/keycloak-operator#local-development for running the operator locally
>  verify that pods are created and running (keycloak and postgresql)
>  Verify that deployment config of postgres doesnt contain initcontainers sections for openshift, but has the same for plain kuberntes
> verify key cloak works fine - sanity check


## Checklist:
- [X] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->