### PR TITLE
KEYCLOAK-16637 Add DB_PORT to Keycloak Deployment

### DIFF
--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -71,6 +71,10 @@ func getKeycloakEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 			Value: PostgresqlServiceName + "." + cr.Namespace,
 		},
 		{
+			Name:  "DB_PORT",
+			Value: fmt.Sprintf("%v", GetExternalDatabasePort(dbSecret)),
+		},
+		{
 			Name:  "DB_DATABASE",
 			Value: GetExternalDatabaseName(dbSecret),
 		},

--- a/pkg/model/keycloak_deployment_test.go
+++ b/pkg/model/keycloak_deployment_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
@@ -25,6 +26,10 @@ func TestKeycloakDeployment_testExperimentalCommand(t *testing.T) {
 
 func TestKeycloakDeployment_testExperimentalVolumesWithConfigMaps(t *testing.T) {
 	testExperimentalVolumesWithConfigMaps(t, KeycloakDeployment)
+}
+
+func TestKeycloakDeployment_testPostgresEnvs(t *testing.T) {
+	testPostgresEnvs(t, KeycloakDeployment)
 }
 
 func testExperimentalEnvs(t *testing.T, deploymentFunction createDeploymentStatefulSet) {
@@ -154,4 +159,56 @@ func testExperimentalVolumesWithConfigMaps(t *testing.T, deploymentFunction crea
 	assert.Equal(t, "testName", volume.Projected.Sources[0].ConfigMap.Name)
 	assert.Equal(t, "testKey", volume.Projected.Sources[0].ConfigMap.Items[0].Key)
 	assert.Equal(t, "testPath", volume.Projected.Sources[0].ConfigMap.Items[0].Path)
+}
+
+func testPostgresEnvs(t *testing.T, deploymentFunction createDeploymentStatefulSet) {
+	//given
+	cr := &v1alpha1.Keycloak{}
+
+	//when
+	envs := deploymentFunction(cr, nil).Spec.Template.Spec.Containers[0].Env
+
+	//then
+	assert.Equal(t, getEnvValueByName(envs, "DB_VENDOR"), "POSTGRES")
+	assert.Equal(t, getEnvValueByName(envs, "DB_SCHEMA"), "public")
+	assert.Equal(t, getEnvValueByName(envs, "DB_ADDR"), PostgresqlServiceName+"."+cr.Namespace)
+	assert.True(t, getEnvValueByName(envs, "DB_PORT") != "")
+	assert.Equal(t, getEnvValueByName(envs, "DB_PORT"), fmt.Sprintf("%v", PostgresDefaultPort))
+	assert.Equal(t, getEnvValueByName(envs, "DB_DATABASE"), PostgresqlDatabase)
+
+	//given
+	cr = &v1alpha1.Keycloak{
+		Spec: v1alpha1.KeycloakSpec{
+			ExternalDatabase: v1alpha1.KeycloakExternalDatabase{
+				Enabled: true,
+			},
+		},
+	}
+
+	//when
+	dbSecret := &v1.Secret{
+		Data: map[string][]byte{
+			DatabaseSecretDatabaseProperty:        []byte("test"),
+			DatabaseSecretExternalAddressProperty: []byte("postgres.example.com"),
+			DatabaseSecretExternalPortProperty:    []byte("12345"),
+		},
+	}
+	envs = deploymentFunction(cr, dbSecret).Spec.Template.Spec.Containers[0].Env
+
+	//then
+	assert.Equal(t, "POSTGRES", getEnvValueByName(envs, "DB_VENDOR"))
+	assert.Equal(t, "public", getEnvValueByName(envs, "DB_SCHEMA"))
+	assert.Equal(t, PostgresqlServiceName+"."+cr.Namespace, getEnvValueByName(envs, "DB_ADDR"))
+	assert.True(t, getEnvValueByName(envs, "DB_PORT") != "")
+	assert.Equal(t, "12345", getEnvValueByName(envs, "DB_PORT"))
+	assert.Equal(t, "test", getEnvValueByName(envs, "DB_DATABASE"))
+}
+
+func getEnvValueByName(envs []v1.EnvVar, name string) string {
+	for _, v := range envs {
+		if v.Name == name {
+			return v.Value
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Add DB_PORT to Keycloak Deployment for connecting to external
Postgres database running on non-default port

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-16637

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->