### PR TITLE
Fix Issue KEYCLOAK-17090; Keycloak Operator Deletes all PVs in a Cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,12 @@ cluster/prepare:
 
 .PHONY: cluster/clean
 cluster/clean:
-	@kubectl get all -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	@kubectl get roles,rolebindings,serviceaccounts keycloak-operator -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	@kubectl get pv,pvc -n $(NAMESPACE) --no-headers=true -o name | xargs kubectl delete -n $(NAMESPACE) || true
-	# Remove all CRDS with keycloak.org in the name
-	@kubectl get crd --no-headers=true -o name | awk '/keycloak.org/{print $1}' | xargs kubectl delete || true
+	@kubectl delete -f deploy/service_account.yaml -n $(NAMESPACE) || true
+	@kubectl delete -f deploy/role_binding.yaml -n $(NAMESPACE) || true
+	@kubectl delete -f deploy/role.yaml -n $(NAMESPACE) || true
 	@kubectl delete namespace $(NAMESPACE) || true
-
+	@kubectl delete -f deploy/crds/ || true
+	
 .PHONY: cluster/clean/monitoring
 cluster/clean/monitoring:
 	@kubectl delete -n $(NAMESPACE) --all blackboxtargets

--- a/README.md
+++ b/README.md
@@ -31,7 +31,19 @@ Please remember to provide a good summary, description as well as steps to repro
 | [KeycloakClient](./deploy/crds/keycloak.org_keycloakclients_crd.yaml) | Represents a client in a keycloak server                 |
 | [KeycloakBackup](./deploy/crds/keycloak.org_keycloakbackups_crd.yaml) | Manage Keycloak database backups                         |
 
-## Deploying to a Cluster
+
+## Deployment to a Kubernetes or Openshift cluster
+
+The official documentation contains installation instruction for this Operator.
+
+[Getting started with keycloak-operator on Openshift](https://www.keycloak.org/getting-started/getting-started-operator-openshift)
+
+[Getting started with keycloak-operator on Kubernetes](https://www.keycloak.org/getting-started/getting-started-operator-kubernetes)
+
+[Operator installation](https://www.keycloak.org/docs/latest/server_installation/index.html#_installing-operator)
+
+
+## Developer Reference
 *Note*: You will need a running Kubernetes or OpenShift cluster to use the Operator
 
 1. Run `make cluster/prepare` # This will apply the necessary Custom Resource Definitions (CRDs) and RBAC rules to the clusters
@@ -41,8 +53,6 @@ Please remember to provide a good summary, description as well as steps to repro
 Once the CRDs and RBAC rules are applied and the operator is running. Use the examples from the operator.
 
 1. Run `kubectl apply -f deploy/examples/keycloak/keycloak.yaml`
-
-## Building from Source
 
 ### Local Development
 *Note*: You will need a running Kubernetes or OpenShift cluster to use the Operator


### PR DESCRIPTION
Removed all generalized delete statements including the deletion of PVs from the Makefile cluster/clean command. This approach deletes the resources created by cluster/prepare.

## JIRA ID
KEYCLOAK-17090

## Additional Information
This changes the Documentation in README.md to be more accurate. 
> To clean the cluster (Removes CRDs, CRs, RBAC and namespace)

(It does not specifically delete CRs, but since its CRDs are deleted, the results should be the identical)


## Verification Steps

Add the steps required to check this change. Following an example.
1. Create a Persistent Volume somewhere in the cluster.
1. `make cluster/prepare`
1. `kubectl apply -f deploy/operator.yaml -f deploy/examples/keycloak/keycloak.yaml`
1. `sleep 120s`
1. `make cluster/clean`
1. `sleep 60s`
1. `kubectl get pv`
1. `kubectl get keycloaks.keycloak.org`
1. `kubectl get pv`


## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

## Additional Notes 
* please check if additional steps are required on OpenShift to remove the Project created by the cluster/prepare command