### PR TITLE
KEYCLOAK-17209 Add support for bind cred secret

### DIFF
--- a/deploy/examples/realm/realm_with_ldap.yaml
+++ b/deploy/examples/realm/realm_with_ldap.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: bindcred
+type: Opaque
+stringData:
+  password: "test-password"
+---
+piVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    app: sso
+  name: ldap-realm
+spec:
+  instanceSelector:
+    matchLabels:
+      app: sso
+  realm:
+    displayName: LDAPRealm
+    enabled: true
+    id: ldap-realm
+    realm: ldap-realm
+    userFederationProviders:
+      - displayName: "ldap"
+        providerName: "ldap"
+        config:
+          vendor: "ad"
+          connectionUrl: "ldap://localhost"
+          bindDn: "USERNAME"
+          bindCredentialSecret: "bindcred"
+          usersDn: DC=example,DC=com"
+          usernameLDAPAttribute: "mail"
+          uuidLDAPAttribute: "objectGUID"
+          searchScope: "2" # sub
+          useTruststoreSpi: "ldapsOnly"
+          trustEmail: "true"
+          userObjectClasses: "person, organizationalPerson, user"
+          rdnLDAPAttribute: "cn"
+          editMode: "READ_ONLY"
+          # debug: "false"
+    userFederationMappers:
+      - name: username
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: mail
+          read.only: 'true'
+          user.model.attribute: username
+      - name: MSAD account controls
+        federationProviderDisplayName: ldap
+        federationMapperType:  msad-user-account-control-mapper
+        config:
+          ldap.password.policy.hints.enabled: 'false'
+      - name: last name
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: sn
+          read.only: 'true'
+          user.model.attribute: lastName
+      - name: email
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: mail
+          read.only: 'true'
+          user.model.attribute: email
+      - name: full name
+        federationProviderDisplayName: ldap
+        federationMapperType: full-name-ldap-mapper
+        config:
+          ldap.full.name.attribute: cn
+          read.only: 'true'
+          write.only: 'false'

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -164,7 +164,7 @@ func (c *Client) DeleteUserRealmRole(role *v1alpha1.KeycloakUserRole, realmName,
 
 func (c *Client) UpdatePassword(user *v1alpha1.KeycloakAPIUser, realmName, newPass string) error {
 	passReset := &v1alpha1.KeycloakAPIPasswordReset{}
-	passReset.Type = "password"
+	passReset.Type = "password" // nolint
 	passReset.Temporary = false
 	passReset.Value = newPass
 	u := fmt.Sprintf("realms/%s/users/%s/reset-password", realmName, user.ID)
@@ -890,6 +890,9 @@ func ConvertRealmSecrets(r *v1alpha1.KeycloakAPIRealm, ns string) (*v1alpha1.Key
 		return nil, err
 	}
 	err = json.Unmarshal(data, &newRealm)
+	if err != nil {
+		return nil, err
+	}
 
 	for i := range newRealm.UserFederationProviders {
 		if newRealm.UserFederationProviders[i].Config["bindCredentialSecret"] != "" {
@@ -919,5 +922,4 @@ func ConvertRealmSecrets(r *v1alpha1.KeycloakAPIRealm, ns string) (*v1alpha1.Key
 	}
 
 	return newRealm, nil
-
 }


### PR DESCRIPTION
This adds support for storing the bind credentials in a secret.

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-17209

## Additional Information
The ldap bind credentials should be stored in a secret instead of in cleartext in the keycloak CR. 
## Verification Steps

Add the steps required to check this change. Following an example.

1. Create a secret in the keycloak namespace that contains the bind password
2. Create a realm that connects to an existing ldap server
```
 apiVersion: keycloak.org/v1alpha1
kind: KeycloakRealm
metadata:
  labels:
    app: sso
  name: ldap-realm
spec:
  instanceSelector:
    matchLabels:
      app: sso
  realm:
    displayName: LDAPRealm
    enabled: true
    id: ldap-realm
    realm: ldap-realm
    userFederationProviders:
      - displayName: "ldap"
        providerName: "ldap"
        config:
          vendor: "ad"
          connectionUrl: "ldap://localhost"
          bindDn: "USERNAME"
          bindCredentialSecret: "bindcred"
          usersDn: DC=example,DC=com"
          usernameLDAPAttribute: "mail"
          uuidLDAPAttribute: "objectGUID"
          searchScope: "2" # sub
          useTruststoreSpi: "ldapsOnly"
          trustEmail: "true"
          userObjectClasses: "person, organizationalPerson, user"
          rdnLDAPAttribute: "cn"
          editMode: "READ_ONLY"
          # debug: "false"
    userFederationMappers:
      - name: username
        federationProviderDisplayName: ldap
        federationMapperType: user-attribute-ldap-mapper
        config:
          always.read.value.from.ldap: 'true'
          is.binary.attribute: 'false'
          is.mandatory.in.ldap: 'true'
          ldap.attribute: mail
          read.only: 'true'
          user.model.attribute: username
      - name: MSAD account controls
        federationProviderDisplayName: ldap
        federationMapperType:  msad-user-account-control-mapper
        config:
          ldap.password.policy.hints.enabled: 'false'
      - name: last name
        federationProviderDisplayName: ldap
        federationMapperType: user-attribute-ldap-mapper
        config:
          always.read.value.from.ldap: 'true'
          is.binary.attribute: 'false'
          is.mandatory.in.ldap: 'true'
          ldap.attribute: sn
          read.only: 'true'
          user.model.attribute: lastName
      - name: email
        federationProviderDisplayName: ldap
        federationMapperType: user-attribute-ldap-mapper
        config:
          always.read.value.from.ldap: 'true'
          is.binary.attribute: 'false'
          is.mandatory.in.ldap: 'true'
          ldap.attribute: mail
          read.only: 'true'
          user.model.attribute: email
      - name: full name
        federationProviderDisplayName: ldap
        federationMapperType: full-name-ldap-mapper
        config:
          ldap.full.name.attribute: cn
          read.only: 'true'
          write.only: 'false'
```
3. Log into the admin keycloak console and validate that the realm was created with the appropriate bind credential password and that it authenticates to ldap successfully
4. Validate that the Bind Credential is not stored in the keycloakrealm CR

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)
