### PR TITLE
MGDSTRM-1659 - Use at least two owners for caches

### DIFF
--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -64,6 +64,15 @@ func getRHSSOEnv(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) []v1.EnvVar {
 			Name:  "OPENSHIFT_DNS_PING_SERVICE_NAME",
 			Value: KeycloakDiscoveryServiceName + "." + cr.Namespace + ".svc.cluster.local",
 		},
+		// Cache settings
+		{
+			Name:  "CACHE_OWNERS_COUNT",
+			Value: "2",
+		},
+		{
+			Name:  "CACHE_OWNERS_AUTH_SESSIONS_COUNT",
+			Value: "2",
+		},
 		{
 			Name: "SSO_ADMIN_USERNAME",
 			ValueFrom: &v1.EnvVarSource{


### PR DESCRIPTION


These are the operator specific changes for rhsso deployment.
Sets the owners count for cache as 2.

## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
JIRA Link: https://issues.redhat.com/browse/MGDSTRM-1659
## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
Sets the owners count for cache as 2.

CACHE_OWNERS_AUTH_SESSIONS_COUNT and CACHE_OWNERS_COUNT are set as 2

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->