### PR TITLE
KEYCLOAK-17209 Add example for configuring ldap

### DIFF
--- a/deploy/examples/keycloak/keycloak-with-vault.yaml
+++ b/deploy/examples/keycloak/keycloak-with-vault.yaml
@@ -5,7 +5,7 @@ metadata:
   name: keycloak-vault
 type: Opaque
 stringData:
-  test-realm_bindCredential: "test-password"
+  ldap-realm_bindCredential: "test-password"
 ---
 apiVersion: keycloak.org/v1alpha1
 kind: Keycloak

--- a/deploy/examples/keycloak/keycloak-with-vault.yaml
+++ b/deploy/examples/keycloak/keycloak-with-vault.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-vault
+type: Opaque
+stringData:
+  test-realm_bindCredential: "test-password"
+---
+apiVersion: keycloak.org/v1alpha1
+kind: Keycloak
+metadata:
+  name: example-keycloak
+  labels:
+    app: sso
+spec:
+  instances: 1
+  externalAccess:
+    enabled: True
+  keycloakDeploymentSpec:
+    experimental:
+      volumes:
+        defaultMode: 0777
+        items:
+          - secret:
+              name: keycloak-vault
+              mountPath: /opt/jboss/keycloak/secrets

--- a/deploy/examples/realm/realm_with_ldap.yaml
+++ b/deploy/examples/realm/realm_with_ldap.yaml
@@ -1,4 +1,4 @@
-piVersion: keycloak.org/v1alpha1
+apiVersion: keycloak.org/v1alpha1
 kind: KeycloakRealm
 metadata:
   labels:

--- a/deploy/examples/realm/realm_with_ldap.yaml
+++ b/deploy/examples/realm/realm_with_ldap.yaml
@@ -1,0 +1,80 @@
+piVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  labels:
+    app: sso
+  name: ldap-realm
+spec:
+  instanceSelector:
+    matchLabels:
+      app: sso
+  realm:
+    displayName: LDAPRealm
+    enabled: true
+    id: ldap-realm
+    realm: ldap-realm
+    userFederationProviders:
+      - displayName: "ldap"
+        providerName: "ldap"
+        config:
+          vendor: "ad"
+          connectionUrl: "ldap://localhost"
+          bindDn: "USERNAME"
+          # This reads the REALM-SECRET from /opt/jboss/keycloak/secrets
+          # In this example, the secret key is called ldap-realm_bindCredential
+          # See deploy/examples/keycloak/keycloak-with-vault.yaml for an
+          # example of how to setup the vault secret directory
+          bindCredential: "${vault.bindCredential}"
+          usersDn: DC=example,DC=com"
+          usernameLDAPAttribute: "mail"
+          uuidLDAPAttribute: "objectGUID"
+          searchScope: "2" # sub
+          useTruststoreSpi: "ldapsOnly"
+          trustEmail: "true"
+          userObjectClasses: "person, organizationalPerson, user"
+          rdnLDAPAttribute: "cn"
+          editMode: "READ_ONLY"
+          # debug: "false"
+    userFederationMappers:
+      - name: username
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: mail
+          read.only: 'true'
+          user.model.attribute: username
+      - name: MSAD account controls
+        federationProviderDisplayName: ldap
+        federationMapperType:  msad-user-account-control-mapper
+        config:
+          ldap.password.policy.hints.enabled: 'false'
+      - name: last name
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: sn
+          read.only: 'true'
+          user.model.attribute: lastName
+      - name: email
+        federationProviderDisplayName: ldap
+        federationMapperType: user-attribute-ldap-mapper
+        config:
+          always.read.value.from.ldap: 'true'
+          is.binary.attribute: 'false'
+          is.mandatory.in.ldap: 'true'
+          ldap.attribute: mail
+          read.only: 'true'
+          user.model.attribute: email
+      - name: full name
+        federationProviderDisplayName: ldap
+        federationMapperType: full-name-ldap-mapper
+        config:
+          ldap.full.name.attribute: cn
+          read.only: 'true'
+          write.only: 'false'

--- a/deploy/examples/realm/realm_with_ldap.yaml
+++ b/deploy/examples/realm/realm_with_ldap.yaml
@@ -78,3 +78,19 @@ spec:
           ldap.full.name.attribute: cn
           read.only: 'true'
           write.only: 'false'
+      - name: groups
+        federationProviderDisplayName: ldap
+        federationMapperType: group-ldap-mapper
+        config:
+          membership.attribute.type: DN
+          group.name.ldap.attribute: cn
+          membership.user.ldap.attribute: sAMAccountName
+          preserve.group.inheritance: 'true'
+          groups.dn: DC=example,DC=com
+          mode: READ_ONLY
+          user.roles.retrieve.strategy: GET_GROUPS_FROM_USER_MEMBEROF_ATTRIBUTE
+          groups.ldap.filter: "(cn=EXAMPLE*)" #Only pull in groups that start with prefix EXAMPLE
+          membership.ldap.attribute: 'true'
+          memberof.ldap.attribute: memberOf
+          group.object.classes: group
+          drop.non.existing.groups.during.sync: 'true'


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-17209

## Additional Information

This adds an example for how to configure ldap while storing the bind credential in the plaintext vault via a mounted secret.

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->