### PR TITLE
KEYCLOAK-17303 ImagePullSecret Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,14 +176,16 @@ NOTE: This functionality works only in OpenShift environment.
 
 All images used by the Operator might be controlled using dedicated Environmental Variables:
 
- | *Image*             | *Environment variable*          | *Default*                                                        |
- | ------------------- | ------------------------------- | ---------------------------------------------------------------- |
- | `Keycloak`          | `RELATED_IMAGE_KEYCLOAK`                | `quay.io/keycloak/keycloak:9.0.2`                                |
- | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
- | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
- | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                |
- | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                    |
- | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
+ | *Image*             | *Image Environment variable*            | *Image Default*                                                   | *imagePullSecret Environment variable*      |
+ | ------------------- | --------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+ | `Keycloak`          | `RELATED_IMAGE_KEYCLOAK`                | `quay.io/keycloak/keycloak:latest`                                | `KEYCLOAK_IMAGE_PULL_SECRET`                |
+ | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4`    | N/A                                         |
+ | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4`           | N/A                                         |
+ | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                 | `KEYCLOAK_INIT_CONTAINER_IMAGE_PULL_SECRET` |
+ | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                     | `RHMI_BACKUP_CONTAINER_IMAGE_PULL_SECRET`   |
+ | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.access.redhat.com/rhscl/postgresql-10-rhel7:1`          | `POSTGRESQL_IMAGE_PULL_SECRET`              |
+
+*Note*: The `imagePullSecret` Environmental Variables allow you to specify a secret to be used when pulling the respective images.
 
 ## Contributing
 

--- a/pkg/model/image_manager_test.go
+++ b/pkg/model/image_manager_test.go
@@ -12,13 +12,13 @@ func TestImageManager_test_default_images(t *testing.T) {
 	imageChooser := NewImageManager()
 
 	//then
-	assert.Equal(t, DefaultKeycloakImage, imageChooser.Images[KeycloakImage])
-	assert.Equal(t, DefaultRHSSOImageOpenJ9, imageChooser.Images[RHSSOImageOpenJ9])
-	assert.Equal(t, DefaultRHSSOImageOpenJDK, imageChooser.Images[RHSSOImageOpenJDK])
-	assert.Equal(t, DefaultRHSSOImageOpenJDK, imageChooser.Images[RHSSOImage])
-	assert.Equal(t, DefaultKeycloakInitContainer, imageChooser.Images[KeycloakInitContainer])
-	assert.Equal(t, DefaultRHSSOInitContainer, imageChooser.Images[RHSSOInitContainer])
-	assert.Equal(t, DefaultRHMIBackupContainer, imageChooser.Images[RHMIBackupContainer])
+	assert.Equal(t, DefaultKeycloakImage, imageChooser[KeycloakImage].Image)
+	assert.Equal(t, DefaultRHSSOImageOpenJ9, imageChooser[RHSSOImageOpenJ9].Image)
+	assert.Equal(t, DefaultRHSSOImageOpenJDK, imageChooser[RHSSOImageOpenJDK].Image)
+	assert.Equal(t, DefaultRHSSOImageOpenJDK, imageChooser[RHSSOImage].Image)
+	assert.Equal(t, DefaultKeycloakInitContainer, imageChooser[KeycloakInitContainer].Image)
+	assert.Equal(t, DefaultRHSSOInitContainer, imageChooser[RHSSOInitContainer].Image)
+	assert.Equal(t, DefaultRHMIBackupContainer, imageChooser[RHMIBackupContainer].Image)
 }
 
 func TestImageManager_test_defining_image_using_environment_variable(t *testing.T) {
@@ -30,7 +30,28 @@ func TestImageManager_test_defining_image_using_environment_variable(t *testing.
 	os.Unsetenv(KeycloakImage)
 
 	//then
-	assert.Equal(t, "test", imageChooser.Images[KeycloakImage])
+	assert.Equal(t, "test", imageChooser[KeycloakImage].Image)
+}
+
+func TestImageManager_test_defining_image_pull_secrets_using_environment_variables(t *testing.T) {
+	//given
+	os.Setenv(keycloakImageIPS, "keycloakImagePullSecret")
+	os.Setenv(keycloakInitContainerIPS, "keycloakInitContainerImagePullSecret")
+	os.Setenv(rhmiBackupContainerIPS, "rhmiBackupContainerImagePullSecret")
+	os.Setenv(postgresqlImageIPS, "postgresqlImagePullSecret")
+
+	//when
+	imageChooser := NewImageManager()
+	os.Unsetenv(keycloakImageIPS)
+	os.Unsetenv(keycloakInitContainerIPS)
+	os.Unsetenv(rhmiBackupContainerIPS)
+	os.Unsetenv(postgresqlImageIPS)
+
+	//then
+	assert.Equal(t, "keycloakImagePullSecret", imageChooser[KeycloakImage].ImagePullSecret.Name)
+	assert.Equal(t, "keycloakInitContainerImagePullSecret", imageChooser[KeycloakInitContainer].ImagePullSecret.Name)
+	assert.Equal(t, "rhmiBackupContainerImagePullSecret", imageChooser[RHMIBackupContainer].ImagePullSecret.Name)
+	assert.Equal(t, "postgresqlImagePullSecret", imageChooser[PostgresqlImage].ImagePullSecret.Name)
 }
 
 func TestImageManager_test_overriding_rhsso_image_using_environment_variable(t *testing.T) {
@@ -42,7 +63,7 @@ func TestImageManager_test_overriding_rhsso_image_using_environment_variable(t *
 	os.Unsetenv(RHSSOImage)
 
 	//then
-	assert.Equal(t, "test", imageChooser.Images[RHSSOImage])
+	assert.Equal(t, "test", imageChooser[RHSSOImage].Image)
 }
 
 func TestImageManager_test_overriding_multiple_images_using_environment_variables(t *testing.T) {
@@ -53,14 +74,14 @@ func TestImageManager_test_overriding_multiple_images_using_environment_variable
 
 	//when
 	imageChooser := NewImageManager()
-	getRHSSOImageResult := imageChooser.getRHSSOImage()
+	getRHSSOImageResult := getRHSSOImage()
 	os.Unsetenv(RHSSOImage)
 	os.Unsetenv(RHSSOImageOpenJ9)
 	os.Unsetenv(RHSSOImageOpenJDK)
 
 	//then
 	assert.Equal(t, "RHSSOImage", getRHSSOImageResult)
-	assert.Equal(t, "RHSSOImage", imageChooser.Images[RHSSOImage])
-	assert.Equal(t, "RHSSOImageOpenJ9", imageChooser.Images[RHSSOImageOpenJ9])
-	assert.Equal(t, "RHSSOImageOpenJDK", imageChooser.Images[RHSSOImageOpenJDK])
+	assert.Equal(t, "RHSSOImage", imageChooser[RHSSOImage].Image)
+	assert.Equal(t, "RHSSOImageOpenJ9", imageChooser[RHSSOImageOpenJ9].Image)
+	assert.Equal(t, "RHSSOImageOpenJDK", imageChooser[RHSSOImageOpenJDK].Image)
 }

--- a/pkg/model/postgresql_aws_backup.go
+++ b/pkg/model/postgresql_aws_backup.go
@@ -21,6 +21,7 @@ func PostgresqlAWSBackup(cr *v1alpha1.KeycloakBackup) *v13.Job {
 		Spec: v13.JobSpec{
 			Template: v1.PodTemplateSpec{
 				Spec: v1.PodSpec{
+					ImagePullSecrets:   postgresqlAwsBackupCommonImagePullSecrets(),
 					Containers:         postgresqlAwsBackupCommonContainers(cr),
 					RestartPolicy:      v1.RestartPolicyNever,
 					ServiceAccountName: PostgresqlBackupServiceAccountName,
@@ -39,6 +40,7 @@ func PostgresqlAWSBackupSelector(cr *v1alpha1.KeycloakBackup) client.ObjectKey {
 
 func PostgresqlAWSBackupReconciled(cr *v1alpha1.KeycloakBackup, currentState *v13.Job) *v13.Job {
 	reconciled := currentState.DeepCopy()
+	reconciled.Spec.Template.Spec.ImagePullSecrets = postgresqlAwsBackupCommonImagePullSecrets()
 	reconciled.Spec.Template.Spec.Containers = postgresqlAwsBackupCommonContainers(cr)
 	reconciled.Spec.Template.Spec.RestartPolicy = v1.RestartPolicyNever
 	reconciled.Spec.Template.Spec.ServiceAccountName = PostgresqlBackupServiceAccountName

--- a/pkg/model/postgresql_aws_periodic_backup.go
+++ b/pkg/model/postgresql_aws_periodic_backup.go
@@ -33,6 +33,7 @@ func PostgresqlAWSPeriodicBackup(cr *v1alpha1.KeycloakBackup) *v1beta1.CronJob {
 				Spec: v13.JobSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
+							ImagePullSecrets:   postgresqlAwsBackupCommonImagePullSecrets(),
 							Containers:         postgresqlAwsBackupCommonContainers(cr),
 							RestartPolicy:      v1.RestartPolicyNever,
 							ServiceAccountName: PostgresqlBackupServiceAccountName,
@@ -54,6 +55,7 @@ func PostgresqlAWSPeriodicBackupSelector(cr *v1alpha1.KeycloakBackup) client.Obj
 func PostgresqlAWSPeriodicBackupReconciled(cr *v1alpha1.KeycloakBackup, currentState *v1beta1.CronJob) *v1beta1.CronJob {
 	reconciled := currentState.DeepCopy()
 	reconciled.Spec.Schedule = cr.Spec.AWS.Schedule
+	reconciled.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = postgresqlAwsBackupCommonImagePullSecrets()
 	reconciled.Spec.JobTemplate.Spec.Template.Spec.Containers = postgresqlAwsBackupCommonContainers(cr)
 	reconciled.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = v1.RestartPolicyNever
 	reconciled.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = PostgresqlBackupServiceAccountName

--- a/pkg/model/postgresql_common_backup.go
+++ b/pkg/model/postgresql_common_backup.go
@@ -9,7 +9,7 @@ func postgresqlAwsBackupCommonContainers(cr *v1alpha1.KeycloakBackup) []v1.Conta
 	return []v1.Container{
 		{
 			Name:    cr.Name,
-			Image:   Images.Images[RHMIBackupContainer],
+			Image:   Images[RHMIBackupContainer].Image,
 			Command: []string{"/opt/intly/tools/entrypoint.sh", "-c", "postgres", "-n", cr.Namespace, "-b", "s3", "-e", ""},
 			Env: []v1.EnvVar{
 				{
@@ -39,4 +39,9 @@ func postgresqlAwsBackupCommonContainers(cr *v1alpha1.KeycloakBackup) []v1.Conta
 			},
 		},
 	}
+}
+
+func postgresqlAwsBackupCommonImagePullSecrets() []v1.LocalObjectReference {
+	secrets := []v1.LocalObjectReference{Images[RHMIBackupContainer].ImagePullSecret}
+	return filterEmptyImagePullSecrets(secrets)
 }

--- a/pkg/model/postgresql_deployment.go
+++ b/pkg/model/postgresql_deployment.go
@@ -63,10 +63,11 @@ func PostgresqlDeployment(cr *v1alpha1.Keycloak, isOpenshift bool) *v13.Deployme
 					},
 				},
 				Spec: v1.PodSpec{
+					ImagePullSecrets: PostgresqlImagePullSecrets(),
 					Containers: []v1.Container{
 						{
 							Name:  PostgresqlDeploymentName,
-							Image: Images.Images[PostgresqlImage],
+							Image: Images[PostgresqlImage].Image,
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: 5432,
@@ -160,7 +161,7 @@ func getPostgresqlDeploymentInitContainer(cr *v1alpha1.Keycloak) []v1.Container 
 	return []v1.Container{
 		{
 			Name:  "init-pvc",
-			Image: Images.Images[PostgresqlImage],
+			Image: Images[PostgresqlImage].Image,
 			SecurityContext: &v1.SecurityContext{
 				RunAsUser: pointer.Int64Ptr(0),
 			},
@@ -192,10 +193,11 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 	reconciled.Spec.Strategy = v13.DeploymentStrategy{
 		Type: v13.RecreateDeploymentStrategyType,
 	}
+	reconciled.Spec.Template.Spec.ImagePullSecrets = PostgresqlImagePullSecrets()
 	reconciled.Spec.Template.Spec.Containers = []v1.Container{
 		{
 			Name:  PostgresqlDeploymentName,
-			Image: Images.Images[PostgresqlImage],
+			Image: Images[PostgresqlImage].Image,
 			Ports: []v1.ContainerPort{
 				{
 					ContainerPort: 5432,
@@ -272,4 +274,9 @@ func PostgresqlDeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Dep
 		},
 	}
 	return reconciled
+}
+
+func PostgresqlImagePullSecrets() []v1.LocalObjectReference {
+	secrets := []v1.LocalObjectReference{Images[PostgresqlImage].ImagePullSecret}
+	return filterEmptyImagePullSecrets(secrets)
 }

--- a/pkg/model/profile_manager.go
+++ b/pkg/model/profile_manager.go
@@ -38,16 +38,16 @@ func (p *ProfileManager) IsRHSSO(cr *v1alpha1.Keycloak) bool {
 
 func (p *ProfileManager) GetKeycloakOrRHSSOImage(cr *v1alpha1.Keycloak) string {
 	if p.IsRHSSO(cr) {
-		return Images.Images[RHSSOImage]
+		return Images[RHSSOImage].Image
 	}
-	return Images.Images[KeycloakImage]
+	return Images[KeycloakImage].Image
 }
 
 func (p *ProfileManager) GetInitContainerImage(cr *v1alpha1.Keycloak) string {
 	if p.IsRHSSO(cr) {
-		return Images.Images[RHSSOInitContainer]
+		return Images[RHSSOInitContainer].Image
 	}
-	return Images.Images[KeycloakInitContainer]
+	return Images[KeycloakInitContainer].Image
 }
 
 func (p *ProfileManager) getProfiles() []string {

--- a/pkg/model/rhsso_deployment.go
+++ b/pkg/model/rhsso_deployment.go
@@ -158,7 +158,7 @@ func RHSSODeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.StatefulSe
 					Containers: []v1.Container{
 						{
 							Name:  KeycloakDeploymentName,
-							Image: Images.Images[RHSSOImage],
+							Image: Images[RHSSOImage].Image,
 							Ports: []v1.ContainerPort{
 								{
 									ContainerPort: KeycloakServicePort,
@@ -215,7 +215,7 @@ func RHSSODeploymentReconciled(cr *v1alpha1.Keycloak, currentState *v13.Stateful
 	reconciled.Spec.Template.Spec.Containers = []v1.Container{
 		{
 			Name:    KeycloakDeploymentName,
-			Image:   Images.Images[RHSSOImage],
+			Image:   Images[RHSSOImage].Image,
 			Args:    cr.Spec.KeycloakDeploymentSpec.Experimental.Args,
 			Command: cr.Spec.KeycloakDeploymentSpec.Experimental.Command,
 			Ports: []v1.ContainerPort{

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -174,3 +174,13 @@ func roleMatches(a v1alpha1.RoleRepresentation, b v1alpha1.RoleRepresentation) b
 	}
 	return a.Name == b.Name
 }
+
+func filterEmptyImagePullSecrets(secrets []v1.LocalObjectReference) []v1.LocalObjectReference {
+	var ret []v1.LocalObjectReference
+	for _, secret := range secrets {
+		if secret.Name != "" {
+			ret = append(ret, secret)
+		}
+	}
+	return ret
+}

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -126,3 +126,15 @@ func TestKeycloakClientReconciler_Test_Role_DifferenceIntersection(t *testing.T)
 	assert.Equal(t, expectedDifference, difference)
 	assert.Equal(t, expectedIntersection, intersection)
 }
+
+func TestUtil_testFilterEmptyImagePullSecrets(t *testing.T) {
+	//given
+	secrets := []v1.LocalObjectReference{{Name: "foo"}, {Name: "bar"}, {Name: ""}}
+
+	//when
+	returnedSecrets := filterEmptyImagePullSecrets(secrets)
+
+	//then
+	expectedSecrets := []v1.LocalObjectReference{{Name: "foo"}, {Name: "bar"}}
+	assert.Equal(t, expectedSecrets, returnedSecrets)
+}


### PR DESCRIPTION
## JIRA ID
[KEYCLOAK-17303](https://issues.redhat.com/browse/KEYCLOAK-17303)

## Additional Information
See JIRA issue for more details - but at a high-level this PR provides configuration of `imagePullSecret` by additional environment variables. This is intended to complement the previously existing environment variables for [external images](https://github.com/keycloak/keycloak-operator/pull/165).

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->