### PR TITLE
KEYCLOAK-17371 add default resync period to keycloak-operator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/keycloak/keycloak-operator/pkg/k8sutil"
 
@@ -104,10 +105,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	syncPeriod := time.Minute * 5
+
 	// Set default manager options
 	options := manager.Options{
 		Namespace:          namespace,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", metricsHost, metricsPort),
+		SyncPeriod:         &syncPeriod,
 	}
 
 	// Add support for MultiNamespace set in WATCH_NAMESPACE (e.g ns1,ns2)


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-13731

## Additional Information
Resulting from a user issue, where a client secret was changed through the UI, and not reset to the correct value by the operator in a timely manner.

## Verification Steps

1. Create a keycloak CR
2. Wait a few minutes without editing the CR
3. See that the operator is reconciling frequently.