### PR TITLE
KEYCLOAK-17449 Adding displayNameHtml to Realm

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -401,6 +401,9 @@ spec:
                 displayName:
                   description: Realm display name.
                   type: string
+                displayNameHtml:
+                  description: Realm display name in HTML.
+                  type: string
                 duplicateEmailsAllowed:
                   description: Duplicate emails
                   type: boolean

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -35,6 +35,9 @@ type KeycloakAPIRealm struct {
 	// Realm display name.
 	// +optional
 	DisplayName string `json:"displayName"`
+	// Realm HTML display name.
+	// +optional
+	DisplayNameHTML string `json:"displayNameHtml,omitempty"`
 	// A set of Keycloak Users.
 	// +optional
 	Users []*KeycloakAPIUser `json:"users,omitempty"`

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -62,6 +62,7 @@ func getKeycloakRealmCR(namespace string) *keycloakv1alpha1.KeycloakRealm {
 				Realm:                        realmName,
 				Enabled:                      true,
 				DisplayName:                  "Operator Testing Realm",
+				DisplayNameHTML:              "<div class='kc-logo-text'><span>Operator Testing Realm</span></div>",
 				BruteForceProtected:          &[]bool{true}[0],
 				PermanentLockout:             &[]bool{false}[0],
 				FailureFactor:                &[]int32{30}[0],


### PR DESCRIPTION
## Additional Information
Mimics `displayName` under realm to also allow setting `displayNameHtml`.

## Verification Steps

1. Create a realm without `displayNameHtml`.
2. Set the value and apply.
3. Verify that the realm was updated as expected.

Tested live and seems to work as expected on Kubernetes, image at `almahmoud/keycloak-operator:displayhtml`