### PR TITLE
KEYCLOAK-17450 add realm attributes to the KeycloakRealm CRD and supporting changes

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Build and push container images
         uses: docker/build-push-action@v1
         with:
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
           repository: ${{ steps.repository.outputs.lowercase }}
-          registry: quay.io
+          #registry: quay.io
           tag_with_ref: true
           always_pull: true
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Build and push container images
         uses: docker/build-push-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
           repository: ${{ steps.repository.outputs.lowercase }}
-          #registry: quay.io
+          registry: quay.io
           tag_with_ref: true
           always_pull: true
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}

--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -648,6 +648,11 @@ spec:
                     type: string
                   description: Email
                   type: object
+                attributes:
+                  additionalProperties:
+                    type: string
+                  description: Attributes
+                  type: object
                 sslRequired:
                   description: Require SSL
                   type: string

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -139,6 +139,10 @@ type KeycloakAPIRealm struct {
 	// +optional
 	SMTPServer map[string]string `json:"smtpServer,omitempty"`
 
+	// Attributes
+	// +optional
+	Attributes map[string]string `json:"attributes,omitempty"`
+
 	// Login Theme
 	// +optional
 	LoginTheme string `json:"loginTheme,omitempty"`

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -537,6 +537,13 @@ func (in *KeycloakAPIRealm) DeepCopyInto(out *KeycloakAPIRealm) {
 			(*out)[key] = val
 		}
 	}
+	if in.Attributes != nil {
+		in, out := &in.Attributes, &out.Attributes
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.InternationalizationEnabled != nil {
 		in, out := &in.InternationalizationEnabled, &out.InternationalizationEnabled
 		*out = new(bool)

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -79,6 +79,9 @@ func getKeycloakRealmCR(namespace string) *keycloakv1alpha1.KeycloakRealm {
 					"envelopeFrom":    "sso@example.com",
 					"ssl":             "",
 				},
+				Attributes: map[string]string{
+					"clientSessionIdleTimeout":        "0",
+				},
 				InternationalizationEnabled: &[]bool{true}[0],
 				SupportedLocales:            []string{"en", "de"},
 				DefaultLocale:               "en",

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -80,7 +80,7 @@ func getKeycloakRealmCR(namespace string) *keycloakv1alpha1.KeycloakRealm {
 					"ssl":             "",
 				},
 				Attributes: map[string]string{
-					"clientSessionIdleTimeout":        "0",
+					"clientSessionIdleTimeout": "0",
 				},
 				InternationalizationEnabled: &[]bool{true}[0],
 				SupportedLocales:            []string{"en", "de"},


### PR DESCRIPTION
…

## KEYCLOAK-17450

## Additional Information
Allows for setting Realm Attributes under the CRD, in particular to allow setting the Frontend URL, which is shown in the first page of the GUI under realm setttings.

## Verification Steps

1. Set an example value in the KeycloakRealm crd attributes object hash like this:
```yaml
spec:
  realm:
    attributes:
      frontendUrl: https://myfrontend-url/auth
```
2. Look at the created Realm in the GUI and verify that this value was set:
![image](https://user-images.githubusercontent.com/1761622/111686377-fd852c80-87f6-11eb-8cf4-94c6cf61882d.png)


## Additional Notes 
Tested and seems to work over at oliverkane/keycloak-operator

Sorry for all the noise with building on this guys.  Super green working with a golang project!