### PR TITLE
KEYCLOAK-16220 KEYCLOAK-15895 Operator communicates with KC using external URLs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       run: |
         make cluster/prepare
         make test/e2e
+        make cluster/clean
     - name: Run e2e tests for local image
       run: |
         make test/e2e-local-image

--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -1030,9 +1030,14 @@ spec:
             credentialSecret:
               description: The secret where the admin credentials are to be found.
               type: string
+            externalURL:
+              description: External URL for accessing Keycloak instance from outside
+                the cluster. Is identical to external.URL if it's specified, otherwise
+                is computed (e.g. from Ingress).
+              type: string
             internalURL:
-              description: Service IP and Port for in-cluster access to the keycloak
-                instance.
+              description: An internal URL (service name) to be used by the admin
+                client.
               type: string
             message:
               description: Human-readable message indicating details about current
@@ -1059,6 +1064,7 @@ spec:
               type: string
           required:
           - credentialSecret
+          - externalURL
           - internalURL
           - message
           - phase

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -226,8 +226,10 @@ type KeycloakStatus struct {
 	SecondaryResources map[string][]string `json:"secondaryResources,omitempty"`
 	// Version of Keycloak or RHSSO running on the cluster.
 	Version string `json:"version"`
-	// Service IP and Port for in-cluster access to the keycloak instance.
+	// An internal URL (service name) to be used by the admin client.
 	InternalURL string `json:"internalURL"`
+	// External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+	ExternalURL string `json:"externalURL"`
 	// The secret where the admin credentials are to be found.
 	CredentialSecret string `json:"credentialSecret"`
 }

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
@@ -737,7 +737,14 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakStatus(ref common.ReferenceCallba
 					},
 					"internalURL": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Service IP and Port for in-cluster access to the keycloak instance.",
+							Description: "An internal URL (service name) to be used by the admin client.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"externalURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -750,7 +757,7 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"phase", "message", "ready", "version", "internalURL", "credentialSecret"},
+				Required: []string{"phase", "message", "ready", "version", "internalURL", "externalURL", "credentialSecret"},
 			},
 		},
 	}

--- a/pkg/controller/keycloak/keycloak_controller.go
+++ b/pkg/controller/keycloak/keycloak_controller.go
@@ -243,16 +243,19 @@ func (r *ReconcileKeycloak) ManageSuccess(instance *v1alpha1.Keycloak, currentSt
 		instance.Status.Phase = v1alpha1.PhaseInitialising
 	}
 
-	// Make this keycloaks url public to allow access via the client
-	if currentState.KeycloakRoute != nil && currentState.KeycloakRoute.Spec.Host != "" { //nolint
-		instance.Status.InternalURL = fmt.Sprintf("https://%v", currentState.KeycloakRoute.Spec.Host)
-	} else if currentState.KeycloakIngress != nil && currentState.KeycloakIngress.Spec.Rules[0].Host != "" {
-		instance.Status.InternalURL = fmt.Sprintf("https://%v", currentState.KeycloakIngress.Spec.Rules[0].Host)
-	} else if currentState.KeycloakService != nil && currentState.KeycloakService.Spec.ClusterIP != "" {
+	if currentState.KeycloakService != nil && currentState.KeycloakService.Spec.ClusterIP != "" {
 		instance.Status.InternalURL = fmt.Sprintf("https://%v.%v.svc:%v",
 			currentState.KeycloakService.Name,
 			currentState.KeycloakService.Namespace,
 			model.KeycloakServicePort)
+	}
+
+	if instance.Spec.External.URL != "" { //nolint
+		instance.Status.ExternalURL = instance.Spec.External.URL
+	} else if currentState.KeycloakRoute != nil && currentState.KeycloakRoute.Spec.Host != "" {
+		instance.Status.ExternalURL = fmt.Sprintf("https://%v", currentState.KeycloakRoute.Spec.Host)
+	} else if currentState.KeycloakIngress != nil && currentState.KeycloakIngress.Spec.Rules[0].Host != "" {
+		instance.Status.ExternalURL = fmt.Sprintf("https://%v", currentState.KeycloakIngress.Spec.Rules[0].Host)
 	}
 
 	// Let the clients know where the admin credentials are stored

--- a/pkg/controller/keycloakrealm/keycloakrealm_controller.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_controller.go
@@ -151,7 +151,6 @@ func (r *ReconcileKeycloakRealm) Reconcile(request reconcile.Request) (reconcile
 		}
 
 		// Compute the current state of the realm
-		log.Info(fmt.Sprintf("got authenticated client for keycloak at %v", keycloak.Status.InternalURL))
 		realmState := common.NewRealmState(r.context, keycloak)
 
 		log.Info(fmt.Sprintf("read state for keycloak %v/%v, realm %v/%v",

--- a/pkg/controller/keycloakuser/keycloakuser_controller.go
+++ b/pkg/controller/keycloakuser/keycloakuser_controller.go
@@ -163,7 +163,6 @@ func (r *ReconcileKeycloakUser) Reconcile(request reconcile.Request) (reconcile.
 			}
 
 			// Compute the current state of the realm
-			log.Info(fmt.Sprintf("got authenticated client for keycloak at %v", keycloak.Status.InternalURL))
 			userState := common.NewUserState(keycloak)
 
 			log.Info(fmt.Sprintf("read state for keycloak %v/%v, realm %v/%v",

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -141,10 +141,10 @@ func keycloakRealmWithIdentityProviderTest(t *testing.T, framework *test.Framewo
 	}
 
 	keycloakCR := getDeployedKeycloakCR(framework, namespace)
-	keycloakInternalURL := keycloakCR.Status.InternalURL
+	keycloakURL := keycloakCR.Status.ExternalURL
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
-	return WaitForSuccessResponseToContain(t, framework, keycloakInternalURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
+	return WaitForSuccessResponseToContain(t, framework, keycloakURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
 }
 
 func keycloakRealmWithClientScopesTest(t *testing.T, framework *test.Framework, ctx *test.Context, namespace string) error {
@@ -265,10 +265,10 @@ func keycloakRealmWithClientScopesTest(t *testing.T, framework *test.Framework, 
 	}
 
 	keycloakCR := getDeployedKeycloakCR(framework, namespace)
-	keycloakInternalURL := keycloakCR.Status.InternalURL
+	keycloakURL := keycloakCR.Status.ExternalURL
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
-	return WaitForSuccessResponseToContain(t, framework, keycloakInternalURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
+	return WaitForSuccessResponseToContain(t, framework, keycloakURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
 }
 
 // These flows (by name, not the exact contents here) are built in and required to exist
@@ -382,10 +382,10 @@ func keycloakRealmWithAuthenticatorFlowTest(t *testing.T, framework *test.Framew
 	}
 
 	keycloakCR := getDeployedKeycloakCR(framework, namespace)
-	keycloakInternalURL := keycloakCR.Status.InternalURL
+	keycloakURL := keycloakCR.Status.ExternalURL
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
-	return WaitForSuccessResponseToContain(t, framework, keycloakInternalURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
+	return WaitForSuccessResponseToContain(t, framework, keycloakURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
 }
 
 func keycloakRealmWithUserFederationTest(t *testing.T, framework *test.Framework, ctx *test.Context, namespace string) error {
@@ -459,10 +459,10 @@ func keycloakRealmWithUserFederationTest(t *testing.T, framework *test.Framework
 	}
 
 	keycloakCR := getDeployedKeycloakCR(framework, namespace)
-	keycloakInternalURL := keycloakCR.Status.InternalURL
+	keycloakURL := keycloakCR.Status.ExternalURL
 
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint
-	return WaitForSuccessResponseToContain(t, framework, keycloakInternalURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
+	return WaitForSuccessResponseToContain(t, framework, keycloakURL+"/auth/realms/"+realmName+"/account", testOperatorIDPDisplayName)
 }
 
 func keycloakUnmanagedRealmTest(t *testing.T, framework *test.Framework, ctx *test.Context, namespace string) error {


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-16220
https://issues.redhat.com/browse/KEYCLOAK-15895

## Additional Information
I'm addressing two issues in a single PR as I believe it makes sense. [KEYCLOAK-15895](https://issues.redhat.com/browse/KEYCLOAK-15895) was blocked by [KEYCLOAK-16220](https://issues.redhat.com/browse/KEYCLOAK-16220) and at the same time [KEYCLOAK-15895](https://issues.redhat.com/browse/KEYCLOAK-15895) verifies that [KEYCLOAK-16220](https://issues.redhat.com/browse/KEYCLOAK-16220) fixed the problem.

## Checklist:
- [X] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)