### PR TITLE
KEYCLOAK-17107 Configuable application context path

### DIFF
--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -82,6 +82,8 @@ type KeycloakSpec struct {
 	// Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
 	// +optional
 	MultiAvailablityZones MultiAvailablityZonesConfig `json:"multiAvailablityZones,omitempty"`
+	// Context Path used by WildFly server. Default to "auth".
+	ContextPath *string `json:"contextPath"`
 }
 
 type DeploymentSpec struct {

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -22,7 +22,8 @@ import (
 )
 
 const (
-	authURL = "auth/realms/master/protocol/openid-connect/token"
+	contextPath = "auth"
+	authURL = fmt.Sprintf("%s/realms/master/protocol/openid-connect/token", contextPath)
 )
 
 type Requester interface {
@@ -48,7 +49,7 @@ func (c *Client) create(obj T, resourcePath, resourceName string) (string, error
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath),
+		fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath),
 		bytes.NewBuffer(jsonValue),
 	)
 	if err != nil {
@@ -228,7 +229,7 @@ func (c *Client) CreateIdentityProvider(identityProvider *v1alpha1.KeycloakIdent
 
 // Generic get function for returning a Keycloak resource
 func (c *Client) get(resourcePath, resourceName string, unMarshalFunc func(body []byte) (T, error)) (T, error) {
-	u := fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath)
+	u := fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath)
 	req, err := http.NewRequest(
 		"GET",
 		u,
@@ -304,7 +305,7 @@ func (c *Client) GetClient(clientID, realmName string) (*v1alpha1.KeycloakAPICli
 }
 
 func (c *Client) GetClientSecret(clientID, realmName string) (string, error) {
-	//"https://{{ rhsso_route }}/auth/admin/realms/{{ rhsso_realm }}/clients/{{ rhsso_client_id }}/client-secret"
+	//"https://{{ rhsso_route }}/{{ context_path }}/admin/realms/{{ rhsso_realm }}/clients/{{ rhsso_client_id }}/client-secret"
 	result, err := c.get(fmt.Sprintf("realms/%s/clients/%s/client-secret", realmName, clientID), "client-secret", func(body []byte) (T, error) {
 		res := map[string]string{}
 		if err := json.Unmarshal(body, &res); err != nil {
@@ -387,7 +388,7 @@ func (c *Client) update(obj T, resourcePath, resourceName string) error {
 
 	req, err := http.NewRequest(
 		"PUT",
-		fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath),
+		fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath),
 		bytes.NewBuffer(jsonValue),
 	)
 	if err != nil {
@@ -439,7 +440,7 @@ func (c *Client) UpdateAuthenticatorConfig(authenticatorConfig *v1alpha1.Authent
 func (c *Client) delete(resourcePath, resourceName string, obj T) error {
 	req, err := http.NewRequest(
 		"DELETE",
-		fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath),
+		fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath),
 		nil,
 	)
 
@@ -450,7 +451,7 @@ func (c *Client) delete(resourcePath, resourceName string, obj T) error {
 		}
 		req, err = http.NewRequest(
 			"DELETE",
-			fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath),
+			fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath),
 			bytes.NewBuffer(jsonValue),
 		)
 		if err != nil {
@@ -523,7 +524,7 @@ func (c *Client) DeleteAuthenticatorConfig(configID, realmName string) error {
 func (c *Client) list(resourcePath, resourceName string, unMarshalListFunc func(body []byte) (T, error)) (T, error) {
 	req, err := http.NewRequest(
 		"GET",
-		fmt.Sprintf("%s/auth/admin/%s", c.URL, resourcePath),
+		fmt.Sprintf("%s/%s/admin/%s", c.URL, contextPath, resourcePath),
 		nil,
 	)
 	if err != nil {
@@ -727,7 +728,7 @@ func (c *Client) ListAuthenticationExecutionsForFlow(flowAlias, realmName string
 }
 
 func (c *Client) Ping() error {
-	u := c.URL + "/auth/"
+	u := fmt.Sprintf("%s/%s/", c.URL contextPath)
 	req, err := http.NewRequest("GET", u, nil)
 	if err != nil {
 		logrus.Errorf("error creating ping request %+v", err)

--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	contextPath = "auth"
+	contextPath = contextPathDefault
 	authURL = fmt.Sprintf("%s/realms/master/protocol/openid-connect/token", contextPath)
 )
 

--- a/pkg/common/client_test.go
+++ b/pkg/common/client_test.go
@@ -13,14 +13,15 @@ import (
 )
 
 const (
-	RealmsGetPath          = "/auth/admin/realms/%s"
-	RealmsCreatePath       = "/auth/admin/realms"
-	RealmsDeletePath       = "/auth/admin/realms/%s"
-	UserCreatePath         = "/auth/admin/realms/%s/users"
-	UserDeletePath         = "/auth/admin/realms/%s/users/%s"
-	UserGetPath            = "/auth/admin/realms/%s/users/%s"
-	UserFindByUsernamePath = "/auth/admin/realms/%s/users?username=%s&max=-1"
-	TokenPath              = "/auth/realms/master/protocol/openid-connect/token" // nolint
+	ContextPath            = "auth"
+	RealmsGetPath          = fmt.Sprintf("/%s/admin/realms/%s", ContextPath)
+	RealmsCreatePath       = fmt.Sprintf("/%s/admin/realms", ContextPath)
+	RealmsDeletePath       = fmt.Sprintf("/%s/admin/realms/%s", ContextPath)
+	UserCreatePath         = fmt.Sprintf("/%s/admin/realms/%s/users", ContextPath)
+	UserDeletePath         = fmt.Sprintf("/%s/admin/realms/%s/users/%s", ContextPath)
+	UserGetPath            = fmt.Sprintf("/%s/admin/realms/%s/users/%s", ContextPath)
+	UserFindByUsernamePath = fmt.Sprintf("/%s/admin/realms/%s/users?username=%s&max=-1", ContextPath)
+	TokenPath              = fmt.Sprintf("/%s/realms/master/protocol/openid-connect/token", ContextPath) // nolint
 )
 
 func getDummyRealm() *v1alpha1.KeycloakRealm {

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -11,8 +11,13 @@ const (
 	KeycloakProbesName                   = ApplicationName + "-probes"
 	KeycloakMetricsRouteName             = ApplicationName + "-metrics-rewrite"
 	StartupScriptsName                   = ApplicationName + "-startup"
+	// XXX These are hard coding the default context path in a constant,
+	// which is not good. These need to be moved to a configuration
+	// parameter instead.
+	// {{{
 	KeycloakMetricsRoutePath             = "/auth/realms/master/metrics"
 	KeycloakMetricsRouteRewritePath      = "/auth/realms/master"
+	// }}}
 	PostgresqlDeploymentComponent        = "database"
 	PostgresqlServiceName                = ApplicationName + "-postgresql"
 	KeycloakDiscoveryServiceName         = ApplicationName + "-discovery"

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -54,4 +54,5 @@ const (
 	MaxUnavailableNumberOfPods            = 1
 	ServiceMonitorName                    = ApplicationName + "-service-monitor"
 	MigrateBackupName                     = "migrate-backup"
+	ContextPathDefault                    = "auth"
 )

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -10,6 +10,7 @@ const (
 	PostgresqlDeploymentName             = ApplicationName + "-postgresql"
 	KeycloakProbesName                   = ApplicationName + "-probes"
 	KeycloakMetricsRouteName             = ApplicationName + "-metrics-rewrite"
+	StartupScriptsName                   = ApplicationName + "-startup"
 	KeycloakMetricsRoutePath             = "/auth/realms/master/metrics"
 	KeycloakMetricsRouteRewritePath      = "/auth/realms/master"
 	PostgresqlDeploymentComponent        = "database"

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	ContextPath                = "auth"
 	LivenessProbeInitialDelay  = 30
 	ReadinessProbeInitialDelay = 40
 	//10s (curl) + 10s (curl) + 2s (just in case)
@@ -405,6 +406,7 @@ func livenessProbe() *v1.Probe {
 					"/bin/sh",
 					"-c",
 					"/probes/" + LivenessProbeProperty,
+					ContextPath,
 				},
 			},
 		},
@@ -423,6 +425,7 @@ func readinessProbe() *v1.Probe {
 					"/bin/sh",
 					"-c",
 					"/probes/" + ReadinessProbeProperty,
+					ContextPath,
 				},
 			},
 		},

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -314,6 +314,10 @@ func KeycloakVolumeMounts(cr *v1alpha1.Keycloak, extensionsPath string) []v1.Vol
 			Name:      KeycloakProbesName,
 			MountPath: "/probes",
 		},
+		{
+			Name:      StartupScriptsName,
+			MountPath: "/opt/jboss/startup-scripts",
+		},
 	}
 
 	mountedVolumes = addVolumeMountsFromKeycloakCR(cr, mountedVolumes)
@@ -359,6 +363,17 @@ func KeycloakVolumes(cr *v1alpha1.Keycloak) []v1.Volume {
 				ConfigMap: &v1.ConfigMapVolumeSource{
 					LocalObjectReference: v1.LocalObjectReference{
 						Name: KeycloakProbesName,
+					},
+					DefaultMode: &[]int32{0555}[0],
+				},
+			},
+		},
+		{
+			Name: StartupScriptsName,
+			VolumeSource: v1.VolumeSource{
+				ConfigMap: &v1.ConfigMapVolumeSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: StartupScriptsName,
 					},
 					DefaultMode: &[]int32{0555}[0],
 				},

--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -21,12 +21,17 @@ func KeycloakIngress(cr *kc.Keycloak) *v1beta1.Ingress {
 			Labels: map[string]string{
 				"app": ApplicationName,
 			},
+			// XXX The default context path is hard coded here,
+			// which is not good. It needs to be updated to use the
+			// context path configuration instead.
+			// {{{
 			Annotations: map[string]string{
 				"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				"nginx.ingress.kubernetes.io/server-snippet": `
                       location ~* "^/auth/realms/master/metrics" {
                           return 301 /auth/realms/master;
                         }`,
+			// }}}
 			},
 		},
 		Spec: v1beta1.IngressSpec{

--- a/pkg/model/keycloak_probes.go
+++ b/pkg/model/keycloak_probes.go
@@ -10,10 +10,23 @@ import (
 const (
 	LivenessProbeImplementation = `#!/bin/bash
 set -e
-curl -s --max-time 10 --fail http://$(hostname -i):8080/auth > /dev/null
+
+if [[ $# != 1 ]]; then
+    exit 1
+fi
+
+context_path=$1
+
+curl -s --max-time 10 --fail "http://$(hostname -i):8080/${context_path}" > /dev/null
 `
 	ReadinessProbeImplementation = `#!/bin/bash
 set -e
+
+if [[ $# != 1 ]]; then
+    exit 1
+fi
+
+context_path=$1
 
 DATASOURCE_POOL_TYPE="data-source"
 DATASOURCE_POOL_NAME="KeycloakDS"
@@ -40,7 +53,7 @@ else
 fi
 
 curl -s --max-time 10 --fail http://localhost:9990/management $AUTH_STRING --header "Content-Type: application/json" -d "{\"operation\":\"test-connection-in-pool\", \"address\":[\"subsystem\",\"datasources\",\"${DATASOURCE_POOL_TYPE}\",\"${DATASOURCE_POOL_NAME}\"], \"json.pretty\":1}"
-curl -s --max-time 10 --fail http://$(hostname -i):8080/auth > /dev/null
+curl -s --max-time 10 --fail "http://$(hostname -i):8080/${context_path}" > /dev/null
 `
 )
 

--- a/pkg/model/monitoring_constants.go
+++ b/pkg/model/monitoring_constants.go
@@ -1,5 +1,7 @@
 package model
 
+// XXX The default context path "/auth" is hard coded into this massive block.
+// It needs to be updated to use the configuration parameter instead.
 const GrafanaDashboardJSON = `{
       "__inputs": [
         {

--- a/pkg/model/service_monitor.go
+++ b/pkg/model/service_monitor.go
@@ -20,6 +20,10 @@ func ServiceMonitor(cr *v1alpha1.Keycloak) *monitoringv1.ServiceMonitor {
 		Spec: monitoringv1.ServiceMonitorSpec{
 			Endpoints: []monitoringv1.Endpoint{
 				{
+					// XXX The default context path is hard
+					// coded here. It needs to be updated
+					// to use the configured context path
+					// instead.
 					Path:   "/auth/realms/master/metrics",
 					Port:   ApplicationName,
 					Scheme: "https",


### PR DESCRIPTION
## JIRA ID

The Keycloak JIRA login process is horribly broken for me, and I cannot login to the ticket board. If I can get help with the login process, I would gladly use it to collaborate.

https://issues.redhat.com/browse/KEYCLOAK-17107

## Additional Information

This PR is an attempt to make the context path configurable. Keycloak has a default context path of "/auth", but it is fully possible and supported to use another path. Unfortunately, with this operator the path has been hard coded to "/auth" into literally every place that a path is used. This makes it impossible to use any other path when using the operator.

This PR is an attempt to make the context path configurable.

There's a lot of stuff that touches the context path in this repository, and I'm not familiar enough with the code base to figure out some of the stuff that needs to be changed. If a maintainer is willing to help provide some guidance, I would be willing to do most of the heavy lifting.