### PR TITLE
KEYCLOAK-17675 Allow supplying a server certificate to use when connecting to keycloak

### DIFF
--- a/pkg/common/client_test.go
+++ b/pkg/common/client_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	jsoniter "github.com/json-iterator/go"
@@ -333,10 +332,8 @@ func TestClient_useKeycloakServerCertificate(t *testing.T) {
 	defer ts.Close()
 
 	pemCert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ts.Certificate().Raw})
-	os.Setenv(KeycloakServerCertEnvKey, string(pemCert))
-	defer os.Setenv(KeycloakServerCertEnvKey, "")
 
-	requester, err := defaultRequester()
+	requester, err := defaultRequester(pemCert)
 	assert.NoError(t, err)
 	httpClient, ok := requester.(*http.Client)
 	assert.True(t, ok)

--- a/pkg/common/client_test.go
+++ b/pkg/common/client_test.go
@@ -326,7 +326,10 @@ func TestClient_login(t *testing.T) {
 
 func TestClient_useKeycloakServerCertificate(t *testing.T) {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.Write([]byte("dummy"))
+		_, err := w.Write([]byte("dummy"))
+		if err != nil {
+			t.Errorf("dummy write failed with error %v", err)
+		}
 	})
 	ts := httptest.NewTLSServer(handler)
 	defer ts.Close()
@@ -343,5 +346,6 @@ func TestClient_useKeycloakServerCertificate(t *testing.T) {
 	assert.NoError(t, err)
 	resp, err := requester.Do(request)
 	assert.NoError(t, err)
+	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, 200)
 }


### PR DESCRIPTION
If the sso-x509-https-secret secret is used to provision a server cert for the keycloak to use
then this will be loaded and set in the http client used to communicate
with the Keycloak server. If the env var is not set, then the behaviour is as before, e.g. insecure.


## Verification Steps

Run the unit test included in the PR. 

`go test -timeout 30s -run ^TestClient_useKeycloakServerCertificate$ github.com/keycloak/keycloak-operator/pkg/common`


## Checklist:
- [X ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)
