### PR TITLE
Allow Password policy to be defined in the keycloak realm CRD

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -77,17 +77,14 @@ spec:
             realm:
               description: Keycloak Realm REST object.
               properties:
-                accessTokenLifespanForImplicitFlow:
-                  description: 'Max time before an access token issued during OpenID Connect Implicit Flow is expired. 
-                     This value is recommended to be shorter than SSO timeout. 
-                     There is no possibility to refresh token during implicit flow, 
-                     thats why there is a separate timeout different to Access Token Lifespan.'
-                  type: integer
-                  format: int32
                 accessTokenLifespan:
-                  description: 'Max time before an access token is expired. This value is recommended to be short relative to the SSO timeout.'
-                  type: integer
+                  description: Access Token Lifespan
                   format: int32
+                  type: integer
+                accessTokenLifespanForImplicitFlow:
+                  description: Access Token Lifespan For Implicit Flow
+                  format: int32
+                  type: integer
                 accountTheme:
                   description: Account Theme
                   type: string
@@ -826,7 +823,7 @@ spec:
                   description: Realm display name.
                   type: string
                 displayNameHtml:
-                  description: Realm display name in HTML.
+                  description: Realm HTML display name.
                   type: string
                 duplicateEmailsAllowed:
                   description: Duplicate emails
@@ -921,6 +918,9 @@ spec:
                   description: Minimum Quick Login Wait
                   format: int32
                   type: integer
+                passwordPolicy:
+                  description: Realm Password Policy
+                  type: string
                 permanentLockout:
                   description: Permanent Lockout
                   type: boolean

--- a/deploy/examples/realm/basic_realm_with_password_policy.yaml
+++ b/deploy/examples/realm/basic_realm_with_password_policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: keycloak.org/v1alpha1
+kind: KeycloakRealm
+metadata:
+  name: example-keycloakrealm
+  labels:
+    app: sso
+spec:
+  realm:
+    id: "basic"
+    realm: "basic"
+    enabled: True
+    displayName: "Basic Realm"
+    passwordPolicy: "lowerCase(1)"
+  instanceSelector:
+    matchLabels:
+      app: sso

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -38,6 +38,9 @@ type KeycloakAPIRealm struct {
 	// Realm HTML display name.
 	// +optional
 	DisplayNameHTML string `json:"displayNameHtml,omitempty"`
+	// Realm Password Policy
+	// +optional
+	PasswordPolicy string `json:"passwordPolicy,omitempty"`
 	// A set of Keycloak Users.
 	// +optional
 	Users []*KeycloakAPIUser `json:"users,omitempty"`

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -559,6 +559,16 @@ func (in *KeycloakAPIRealm) DeepCopyInto(out *KeycloakAPIRealm) {
 			(*out)[key] = outVal
 		}
 	}
+	if in.AccessTokenLifespanForImplicitFlow != nil {
+		in, out := &in.AccessTokenLifespanForImplicitFlow, &out.AccessTokenLifespanForImplicitFlow
+		*out = new(int32)
+		**out = **in
+	}
+	if in.AccessTokenLifespan != nil {
+		in, out := &in.AccessTokenLifespan, &out.AccessTokenLifespan
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -63,6 +63,7 @@ func getKeycloakRealmCR(namespace string) *keycloakv1alpha1.KeycloakRealm {
 				Enabled:                            true,
 				DisplayName:                        "Operator Testing Realm",
 				DisplayNameHTML:                    "<div class='kc-logo-text'><span>Operator Testing Realm</span></div>",
+				PasswordPolicy:                     "lowerCase(1)",
 				BruteForceProtected:                &[]bool{true}[0],
 				PermanentLockout:                   &[]bool{false}[0],
 				FailureFactor:                      &[]int32{30}[0],


### PR DESCRIPTION
## https://issues.redhat.com/browse/KEYCLOAK-17607

## Additional Information
Setting up a password policy for realms in KeyCLoak is a frequent requirement by the customers. This change allows the realm yaml to specify the password policy for the realm

## Verification Steps
Run the local setup make code/run
DEfine password policy as per deploy/examples/realm/basic_realm_with_password_policy.yaml
Verify in the relam/authentication left bar of the Keycloak GUI and see;etc the "Passwor dPolicy" tab on the right.

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->