### PR TITLE
Update to latest stable keycloak-init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All images used by the Operator might be controlled using dedicated Environmenta
  | `Keycloak`          | `RELATED_IMAGE_KEYCLOAK`                | `quay.io/keycloak/keycloak:9.0.2`                                |
  | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
- | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                |
+ | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:12.0.4`                |
  | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                    |
  | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
 

--- a/pkg/model/constants.go
+++ b/pkg/model/constants.go
@@ -44,7 +44,7 @@ const (
 	RouteLoadBalancingStrategy            = "source"
 	IngressDefaultHost                    = "keycloak.local"
 	PostgresqlBackupServiceAccountName    = "keycloak-operator"
-	KeycloakExtensionEnvVar               = "KEYCLOAK_EXTENSIONS"
+	KeycloakExtensionEnvVar               = "KEYCLOAK_EXTENSION"
 	KeycloakExtensionPath                 = "/opt/jboss/keycloak/standalone/deployments"
 	KeycloakExtensionsInitContainerPath   = "/opt/extensions"
 	RhssoExtensionPath                    = "/opt/eap/standalone/deployments"

--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -18,7 +18,7 @@ const (
 	DefaultKeycloakImage         = "quay.io/keycloak/keycloak:latest"
 	DefaultRHSSOImageOpenJ9      = "registry.redhat.io/rh-sso-7/sso74-openj9-openshift-rhel8:7.4"
 	DefaultRHSSOImageOpenJDK     = "registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4"
-	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:master"
+	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:12.0.4"
 	DefaultRHSSOInitContainer    = "registry.redhat.io/rh-sso-7-tech-preview/sso74-init-container-rhel8:7.4"
 	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.16"
 	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"


### PR DESCRIPTION
KEYCLOAK-17330

The keycloak-init-container image is currently pinned to the "master"
shared tag, which has not been updated in a year.

This commit updates the image tag to use the latest stable tag for the
container.

This container comes with a couple of benefits:

* Accurate URL parsing, the Python parsing has issues.
* Ability to use basic auth URLs for extensions.
* Much smaller image size.

## JIRA ID

[KEYCLOAK-17330](https://issues.redhat.com/browse/KEYCLOAK-17330)

## Additional Information

Allows the use of private extensions via the use of a basic auth URL.

## Verification Steps

Add the steps required to check this change. Following an example.

1. Create a keycloak resource with an extension using a basic auth URL.
2. Check the keycloak-init container log to verify it downloaded the extension
3. Check the keycloak container to verify the extension was installed correctly

## Checklist:
- [ ] Automated Tests
- [x] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [x] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)