### PR TITLE
KEYCLOAK-17795 Default/OptionalClientScope are not properly handled i…

### DIFF
--- a/pkg/common/cluster_actions.go
+++ b/pkg/common/cluster_actions.go
@@ -36,6 +36,10 @@ type ActionRunner interface {
 	DeleteClientRealmScopeMappings(keycloakClient *v1alpha1.KeycloakClient, mappings *[]v1alpha1.RoleRepresentation, realm string) error
 	CreateClientClientScopeMappings(keycloakClient *v1alpha1.KeycloakClient, mappings *v1alpha1.ClientMappingsRepresentation, realm string) error
 	DeleteClientClientScopeMappings(keycloakClient *v1alpha1.KeycloakClient, mappings *v1alpha1.ClientMappingsRepresentation, realm string) error
+	UpdateClientDefaultClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error
+	DeleteClientDefaultClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error
+	UpdateClientOptionalClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error
+	DeleteClientOptionalClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error
 	CreateUser(obj *v1alpha1.KeycloakUser, realm string) error
 	UpdateUser(obj *v1alpha1.KeycloakUser, realm string) error
 	DeleteUser(id, realm string) error
@@ -190,6 +194,34 @@ func (i *ClusterActionRunner) CreateClientClientScopeMappings(keycloakClient *v1
 		return errors.Errorf("cannot perform client client scope create when client is nil")
 	}
 	return i.keycloakClient.CreateClientClientScopeMappings(keycloakClient.Spec.Client, mappings, realm)
+}
+
+func (i *ClusterActionRunner) DeleteClientDefaultClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error {
+	if i.keycloakClient == nil {
+		return errors.Errorf("cannot perform client default client scope delete when client is nil")
+	}
+	return i.keycloakClient.DeleteClientDefaultClientScope(keycloakClient.Spec.Client, clientScope, realm)
+}
+
+func (i *ClusterActionRunner) UpdateClientDefaultClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error {
+	if i.keycloakClient == nil {
+		return errors.Errorf("cannot perform client default client scope create when client is nil")
+	}
+	return i.keycloakClient.UpdateClientDefaultClientScope(keycloakClient.Spec.Client, clientScope, realm)
+}
+
+func (i *ClusterActionRunner) DeleteClientOptionalClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error {
+	if i.keycloakClient == nil {
+		return errors.Errorf("cannot perform client optional client scope delete when client is nil")
+	}
+	return i.keycloakClient.DeleteClientOptionalClientScope(keycloakClient.Spec.Client, clientScope, realm)
+}
+
+func (i *ClusterActionRunner) UpdateClientOptionalClientScope(keycloakClient *v1alpha1.KeycloakClient, clientScope *v1alpha1.KeycloakClientScope, realm string) error {
+	if i.keycloakClient == nil {
+		return errors.Errorf("cannot perform client optional client scope create when client is nil")
+	}
+	return i.keycloakClient.UpdateClientOptionalClientScope(keycloakClient.Spec.Client, clientScope, realm)
 }
 
 func (i *ClusterActionRunner) DeleteClientClientScopeMappings(keycloakClient *v1alpha1.KeycloakClient, mappings *v1alpha1.ClientMappingsRepresentation, realm string) error {
@@ -440,6 +472,34 @@ type DeleteClientClientScopeMappingsAction struct {
 	Realm    string
 }
 
+type UpdateClientDefaultClientScopeAction struct {
+	ClientScope *v1alpha1.KeycloakClientScope
+	Ref         *v1alpha1.KeycloakClient
+	Msg         string
+	Realm       string
+}
+
+type DeleteClientDefaultClientScopeAction struct {
+	ClientScope *v1alpha1.KeycloakClientScope
+	Ref         *v1alpha1.KeycloakClient
+	Msg         string
+	Realm       string
+}
+
+type UpdateClientOptionalClientScopeAction struct {
+	ClientScope *v1alpha1.KeycloakClientScope
+	Ref         *v1alpha1.KeycloakClient
+	Msg         string
+	Realm       string
+}
+
+type DeleteClientOptionalClientScopeAction struct {
+	ClientScope *v1alpha1.KeycloakClientScope
+	Ref         *v1alpha1.KeycloakClient
+	Msg         string
+	Realm       string
+}
+
 type ConfigureRealmAction struct {
 	Ref *v1alpha1.KeycloakRealm
 	Msg string
@@ -543,6 +603,22 @@ func (i CreateClientClientScopeMappingsAction) Run(runner ActionRunner) (string,
 
 func (i DeleteClientClientScopeMappingsAction) Run(runner ActionRunner) (string, error) {
 	return i.Msg, runner.DeleteClientClientScopeMappings(i.Ref, i.Mappings, i.Realm)
+}
+
+func (i UpdateClientDefaultClientScopeAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.UpdateClientDefaultClientScope(i.Ref, i.ClientScope, i.Realm)
+}
+
+func (i DeleteClientDefaultClientScopeAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.DeleteClientDefaultClientScope(i.Ref, i.ClientScope, i.Realm)
+}
+
+func (i UpdateClientOptionalClientScopeAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.UpdateClientOptionalClientScope(i.Ref, i.ClientScope, i.Realm)
+}
+
+func (i DeleteClientOptionalClientScopeAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.DeleteClientOptionalClientScope(i.Ref, i.ClientScope, i.Realm)
 }
 
 func (i DeleteRealmAction) Run(runner ActionRunner) (string, error) {

--- a/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
+++ b/pkg/controller/keycloakclient/keycloakclient_reconciler_test.go
@@ -160,6 +160,8 @@ func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 				ClientID:                     "test",
 				Secret:                       "test",
 				AuthorizationServicesEnabled: true,
+				DefaultClientScopes:          []string{"profile"},
+				OptionalClientScopes:         []string{"email"},
 			},
 			Roles: []v1alpha1.RoleRepresentation{
 				{ID: "delete_recreateID2", Name: "delete_recreate"},
@@ -197,6 +199,9 @@ func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 			ClientMappings: map[string]v1alpha1.ClientMappingsRepresentation{"someclient": {Mappings: []v1alpha1.RoleRepresentation{{Name: "a"}, {Name: "b"}}}},
 			RealmMappings:  []v1alpha1.RoleRepresentation{{Name: "ra"}, {Name: "rb"}},
 		},
+		AvailableClientScopes: []v1alpha1.KeycloakClientScope{{Name: "address", ID: "222"}, {Name: "email", ID: "421"}, {Name: "profile", ID: "314"}},
+		DefaultClientScopes:   []v1alpha1.KeycloakClientScope{},
+		OptionalClientScopes:  []v1alpha1.KeycloakClientScope{{Name: "address", ID: "222"}},
 	}
 
 	// when
@@ -236,7 +241,14 @@ func TestKeycloakClientReconciler_Test_Update_Client(t *testing.T) {
 	assert.IsType(t, common.DeleteClientRealmScopeMappingsAction{}, desiredState[12])
 	assert.IsType(t, common.DeleteClientClientScopeMappingsAction{}, desiredState[13])
 
-	assert.Equal(t, 14, len(desiredState))
+	assert.IsType(t, common.UpdateClientDefaultClientScopeAction{}, desiredState[14])
+	assert.Equal(t, "314", desiredState[14].(common.UpdateClientDefaultClientScopeAction).ClientScope.ID)
+	assert.IsType(t, common.UpdateClientOptionalClientScopeAction{}, desiredState[15])
+	assert.Equal(t, "421", desiredState[15].(common.UpdateClientOptionalClientScopeAction).ClientScope.ID)
+	assert.IsType(t, common.DeleteClientOptionalClientScopeAction{}, desiredState[16])
+	assert.Equal(t, "222", desiredState[16].(common.DeleteClientOptionalClientScopeAction).ClientScope.ID)
+
+	assert.Equal(t, 17, len(desiredState))
 }
 
 func TestKeycloakClientReconciler_Test_Marshal_Client(t *testing.T) {

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -174,3 +174,48 @@ func roleMatches(a v1alpha1.RoleRepresentation, b v1alpha1.RoleRepresentation) b
 	}
 	return a.Name == b.Name
 }
+
+// FIXME Find a better way to refactor this code with role difference part above
+// returned clientScopes are always from a
+func ClientScopeDifferenceIntersection(a []v1alpha1.KeycloakClientScope, b []v1alpha1.KeycloakClientScope) (d []v1alpha1.KeycloakClientScope, i []v1alpha1.KeycloakClientScope) {
+	for _, clientScope := range a {
+		if hasMatchingClientScope(b, clientScope) {
+			i = append(i, clientScope)
+		} else {
+			d = append(d, clientScope)
+		}
+	}
+	return d, i
+}
+
+func hasMatchingClientScope(clientScopes []v1alpha1.KeycloakClientScope, otherClientScope v1alpha1.KeycloakClientScope) bool {
+	for _, clientScope := range clientScopes {
+		if clientScopeMatches(clientScope, otherClientScope) {
+			return true
+		}
+	}
+	return false
+}
+
+func clientScopeMatches(a v1alpha1.KeycloakClientScope, b v1alpha1.KeycloakClientScope) bool {
+	if a.ID != "" && b.ID != "" {
+		return a.ID == b.ID
+	}
+	return a.Name == b.Name
+}
+
+func FilterClientScopesByNames(clientScopes []v1alpha1.KeycloakClientScope, names []string) (filteredScopes []v1alpha1.KeycloakClientScope) {
+	hashMap := make(map[string]v1alpha1.KeycloakClientScope)
+
+	for _, scope := range clientScopes {
+		hashMap[scope.Name] = scope
+	}
+
+	for _, name := range names {
+		if scope, retrieved := hashMap[name]; retrieved {
+			filteredScopes = append(filteredScopes, scope)
+		}
+	}
+
+	return filteredScopes
+}

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -126,3 +126,31 @@ func TestKeycloakClientReconciler_Test_Role_DifferenceIntersection(t *testing.T)
 	assert.Equal(t, expectedDifference, difference)
 	assert.Equal(t, expectedIntersection, intersection)
 }
+
+func TestKeycloakClientReconciler_Test_ClientScope_DifferenceIntersection(t *testing.T) {
+	// given
+	a := []v1alpha1.KeycloakClientScope{
+		{Name: "a"},
+		{ID: "ignored", Name: "b"},
+		{ID: "cID", Name: "c"},
+	}
+	b := []v1alpha1.KeycloakClientScope{
+		{Name: "b"},
+		{ID: "cID", Name: "differentName"},
+		{Name: "d"},
+	}
+
+	// when
+	difference, intersection := ClientScopeDifferenceIntersection(a, b)
+
+	// then
+	expectedDifference := []v1alpha1.KeycloakClientScope{
+		{Name: "a"},
+	}
+	expectedIntersection := []v1alpha1.KeycloakClientScope{
+		{ID: "ignored", Name: "b"},
+		{ID: "cID", Name: "c"},
+	}
+	assert.Equal(t, expectedDifference, difference)
+	assert.Equal(t, expectedIntersection, intersection)
+}


### PR DESCRIPTION
…n KeycloakClient by operator

## JIRA ID
KEYCLOAK-17795

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

1. Create a KeycloakClient CR with defaultClientScopes and optionalClientScopes:
```yaml
apiVersion: keycloak.org/v1alpha1
kind: KeycloakClient
metadata:
  name: test-client
spec:
  realmSelector:
    matchLabels:
      keycloak-realm: dummyrealm
  client:
    clientId: test-client
    name: test-client
    protocol: openid-connect
    optionalClientScopes:
    - email
    defaultClientScopes:
    - phone
    - profile
```
2. Go to the Keycloak console and check client scope tab for this client. 
3. Assigned default and optional client scope lists should be properly filled.
-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->