### PR TITLE
enable UMA from within the operator

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -807,6 +807,9 @@ spec:
                       useTemplateScope:
                         description: True to use Template Scope.
                         type: boolean
+                      userManagedAccessAllowed:
+                        description: If enabled, users are allowed to manage their resources and permissions using the Account Management Console.
+                        type: boolean
                       webOrigins:
                         description: A list of valid Web Origins.
                         items:

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -184,6 +184,10 @@ type KeycloakAPIRealm struct {
 	// Access Token Lifespan
 	// +optional
 	AccessTokenLifespan *int32 `json:"accessTokenLifespan,omitempty"`
+
+	// User Managed Access Allowed
+	// +optional
+	UserManagedAccessAllowed *bool `json:"userManagedAccessAllowed,omitempty"`
 }
 
 type RoleRepresentationArray []RoleRepresentation

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -84,6 +84,7 @@ func getKeycloakRealmCR(namespace string) *keycloakv1alpha1.KeycloakRealm {
 					"ssl":             "",
 				},
 				InternationalizationEnabled: &[]bool{true}[0],
+				UserManagedAccessAllowed:    &[]bool{true}[0],
 				SupportedLocales:            []string{"en", "de"},
 				DefaultLocale:               "en",
 				LoginTheme:                  "keycloak",


### PR DESCRIPTION
## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-18024

## Additional Information

Currently its not possible to control the userManagedAccessAllowed property on keycloak realm using the operator. We want to setup a keycloak realm using the operator with UMA enabled, so we would need this setting.


## Verification Steps

Add the steps required to check this change. Following an example.

1. create a KeycloakRealm custom resources with spec.realm userManagedAccessAllowed set to true
2. wait for the resource to be created in the keycloak server
3. check if UMA allowed setting is enabled on the created realm

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

