### PR TITLE
KEYCLOAK-18287 fix grafana dashboard watch

### DIFF
--- a/pkg/common/auto_detect.go
+++ b/pkg/common/auto_detect.go
@@ -72,7 +72,7 @@ func (b *Background) detectMonitoringResources() {
 
 	// detect the GrafanaDashboard resource type resourceExists on the cluster
 	resourceExists, _ = k8sutil.ResourceExists(b.dc, grafanav1alpha1.SchemeGroupVersion.String(), grafanav1alpha1.GrafanaDashboardKind)
-	stateManager.SetState(monitoringv1.ServiceMonitorsKind, resourceExists)
+	stateManager.SetState(grafanav1alpha1.GrafanaDashboardKind, resourceExists)
 }
 
 func (b *Background) detectOpenshift() {


### PR DESCRIPTION
## JIRA ID
KEYCLOAK-18287

## Additional Information
Grafana dashboard watch was being created incorrectly. 

## Verification Steps
Install from this branch and confirm keycloak metrics grafana dashboard gets created. 


## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->