### PR TITLE
KEYCLOAK-17162: Add Support for ServiceAccount

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -876,6 +876,9 @@ spec:
                           - name
                           type: object
                         type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
                       volumes:
                         description: Additional volume mounts
                         properties:

--- a/deploy/examples/keycloak/keycloak-with-experimental-settings.yaml
+++ b/deploy/examples/keycloak/keycloak-with-experimental-settings.yaml
@@ -27,6 +27,11 @@ metadata:
 stringData:
   realm2_bindcred: "password"
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account-keycloak
+---
 apiVersion: keycloak.org/v1alpha1
 kind: Keycloak
 metadata:
@@ -50,7 +55,7 @@ spec:
           - name: keytab
             mountPath: /keytabs
             secrets:
-              - keytab
+              - keytabs
           - name: vault
             mountPath: /opt/jboss/keycloak/secrets
             secrets:
@@ -81,3 +86,4 @@ spec:
                   values:
                   - keycloak
               topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: service-account-keycloak

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -121,6 +121,9 @@ type ExperimentalSpec struct {
 	// Affinity settings
 	//+optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	// ServiceAccountName settings
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type VolumesSpec struct {

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -234,6 +234,7 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.Statefu
 							Resources:      getResources(cr),
 						},
 					},
+					ServiceAccountName: getServiceAccountName(cr),
 				},
 			},
 		},
@@ -485,4 +486,11 @@ func KeycloakPodAffinity(cr *v1alpha1.Keycloak) *v1.Affinity {
 			},
 		},
 	}
+}
+
+func getServiceAccountName(cr *v1alpha1.Keycloak) string {
+	if cr.Spec.KeycloakDeploymentSpec.Experimental.ServiceAccountName == "" {
+		return "default"
+	}
+	return cr.Spec.KeycloakDeploymentSpec.Experimental.ServiceAccountName
 }

--- a/pkg/model/keycloak_deployment_test.go
+++ b/pkg/model/keycloak_deployment_test.go
@@ -49,6 +49,14 @@ func TestKeycloakDeployment_testAffinityExperimental(t *testing.T) {
 	testAffinityExperimentalAffinitySet(t, KeycloakDeployment)
 }
 
+func TestKeycloakDeployment_testServiceAccountSetExperimental(t *testing.T) {
+	testServiceAccountSet(t, KeycloakDeployment)
+}
+
+func TestKeycloakDeployment_testServiceAccountDefaultExperimental(t *testing.T) {
+	testServiceAccountDefault(t, KeycloakDeployment)
+}
+
 func testExperimentalEnvs(t *testing.T, deploymentFunction createDeploymentStatefulSet) {
 	//given
 	dbSecret := &v1.Secret{}
@@ -435,4 +443,31 @@ func testAffinityExperimentalAffinitySet(t *testing.T, deploymentFunction create
 	assert.Equal(t, "In", string(matchExprOperator1))
 	assert.Equal(t, ApplicationName, matchExpVal1)
 	assert.Equal(t, "kubernetes.io/hostname", topologyKey1)
+}
+
+func testServiceAccountSet(t *testing.T, deploymentFunction createDeploymentStatefulSet) {
+	//given
+	dbSecret := &v1.Secret{}
+	cr := &v1alpha1.Keycloak{}
+
+	//If serviceAccountName is set in the cr, is should manifest itself in the statefulset
+	cr.Spec.KeycloakDeploymentSpec.Experimental.ServiceAccountName = "test"
+
+	//when
+	serviceAccountName := deploymentFunction(cr, dbSecret).Spec.Template.Spec.ServiceAccountName
+
+	assert.Equal(t, "test", serviceAccountName)
+}
+
+func testServiceAccountDefault(t *testing.T, deploymentFunction createDeploymentStatefulSet) {
+	//given
+	dbSecret := &v1.Secret{}
+	cr := &v1alpha1.Keycloak{}
+
+	//If serviceAccountName is not set in the cr, then the serviceAccountName should be default
+
+	//when
+	serviceAccountName := deploymentFunction(cr, dbSecret).Spec.Template.Spec.ServiceAccountName
+
+	assert.Equal(t, "default", serviceAccountName)
 }


### PR DESCRIPTION
## JIRA ID 

KEYCLOAK-17162: Add Support for ServiceAccount

## Additional Information
The  Keycloak StatefulSet currently has the serviceAccountName set to be "default". 

This is sufficient in most cases, but we need to pull the Keycloak Image from a repository that requires an imagePullSecret.
This doesn't work with the "default" ServiceAccount.
 
As we deploy everything with helm charts, it is very difficult to change the existing "default"-ServiceAccount.

We would like to create a specific ServiceAccount for Keycloak that has the imagePullSecrets set as needed and configure Keycloak to use this Service Account.

This pull request enables this without changing the default behavior if the serviceAccountName is not set.

## Verification Steps

```
k apply -f -
apiVersion: keycloak.org/v1alpha1
kind: Keycloak
metadata:
  name: example-keycloak
  labels:
    app: sso
spec:
  instances: 1
  extensions:
    - https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar
  externalAccess:
    enabled: True
  podDisruptionBudget:
    enabled: True
```
```
kubectl get statefulset keycloak -oyaml | grep serviceAccountNa
serviceAccountName: default
```

-->

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->