### PR TITLE
KEYCLOAK-18868 Keycloak user secret namespace fix

### DIFF
--- a/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
+++ b/pkg/controller/keycloakrealm/keycloakrealm_reconciler.go
@@ -97,8 +97,12 @@ func (i *KeycloakRealmReconciler) getDesiredUserSate(state *common.RealmState, c
 	val, ok := state.RealmUserSecrets[user.UserName]
 	if !ok || val == nil {
 		return &common.GenericCreateAction{
-			Ref: model.RealmCredentialSecret(cr, user, &i.Keycloak),
-			Msg: fmt.Sprintf("create credential secret for user %v in realm %v/%v", user.UserName, cr.Namespace, cr.Spec.Realm.Realm),
+			Ref: model.RealmCredentialSecret(cr, cr.Namespace, user, &i.Keycloak),
+			Msg: fmt.Sprintf("create credential secret for user %v/%v in realm %v/%v",
+				cr.Namespace,
+				user.UserName,
+				cr.Namespace,
+				cr.Spec.Realm.Realm),
 		}
 	}
 

--- a/pkg/controller/keycloakuser/keycloakuser_reconciler.go
+++ b/pkg/controller/keycloakuser/keycloakuser_reconciler.go
@@ -147,10 +147,11 @@ func (i *KeycloakuserReconciler) getUserSecretDesiredState(state *common.UserSta
 	// deleted
 	if state.Secret == nil {
 		return &common.GenericCreateAction{
-			Ref: model.RealmCredentialSecret(&i.Realm, &cr.Spec.User, &i.Keycloak),
-			Msg: fmt.Sprintf("create credential secret for user %v in realm %v/%v",
-				cr.Spec.User.UserName,
+			Ref: model.RealmCredentialSecret(&i.Realm, cr.Namespace, &cr.Spec.User, &i.Keycloak),
+			Msg: fmt.Sprintf("create credential secret for user %v/%v in realm %v/%v",
 				cr.Namespace,
+				cr.Spec.User.UserName,
+				i.Realm.Namespace,
 				i.Realm.Spec.Realm.Realm),
 		}
 	}

--- a/pkg/model/realm_credential_secret.go
+++ b/pkg/model/realm_credential_secret.go
@@ -7,12 +7,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func RealmCredentialSecret(cr *v1alpha1.KeycloakRealm, user *v1alpha1.KeycloakAPIUser, keycloak *v1alpha1.Keycloak) *v1.Secret {
+func RealmCredentialSecret(cr *v1alpha1.KeycloakRealm, namespace *string, user *v1alpha1.KeycloakAPIUser, keycloak *v1alpha1.Keycloak) *v1.Secret {
 	outputSecretName := GetRealmUserSecretName(keycloak.Namespace, cr.Spec.Realm.Realm, user.UserName)
 
 	outputSecret := &v1.Secret{}
 	outputSecret.ObjectMeta = v12.ObjectMeta{
-		Namespace: cr.Namespace,
+		Namespace: namespace,
 		Name:      outputSecretName,
 	}
 	outputSecret.Data = map[string][]byte{


### PR DESCRIPTION
## Additional Information
Currently something like this can happen:
```
{"level":"info","ts":1626538984.2275712,"logger":"action_runner","msg":"(    2)     FAILED create credential secret for user realm_user in realm services/main"}
{"level":"debug","ts":1626538984.2278504,"logger":"controller-runtime.manager.events","msg":"Warning","object":{"kind":"KeycloakUser","namespace":"services","name":"example-user","uid":"de368f9a-d958-427b-bcf8-94d68389e479","apiVersion":"keycloak.org/v1alpha1","resourceVersion":"17349053"},"reason":"ProcessingError","message":"cross-namespace owner references are disallowed, owner's namespace services, obj's namespace keycloak"}
```
The realm is in the keycloak namespace, the user is in the services namespace though, thus not only services/main is incorrect but also a cross namespace resource cannot be created

## Verification Steps

Add the steps required to check this change. Following an example.

1. Setup keycloak-operator to watch multiple namespaces (check operator sdk instructions)
2. Create a realm in one namespace
3. Create user in another namespace
4. Check operator logs (possibly on debug)

## Additional Notes 
Clients can already be created accross namespaces, the secret is properly created in the correct namespace so this here is just fixing it for users and bringing it in line.