### PR TITLE
KEYCLOAK-18869 Authentication flow binding overrides

### DIFF
--- a/deploy/crds/keycloak.org_keycloakclients_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakclients_crd.yaml
@@ -47,6 +47,11 @@ spec:
                       type: string
                     description: Client Attributes.
                     type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
                   authorizationServicesEnabled:
                     description: True if fine-grained authorization support is enabled
                       for this client.

--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -265,6 +265,11 @@ spec:
                             type: string
                           description: Client Attributes.
                           type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
                         authorizationServicesEnabled:
                           description: True if fine-grained authorization support
                             is enabled for this client.

--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -164,6 +164,9 @@ type KeycloakAPIClient struct {
 	// Authorization settings for this resource server.
 	// +optional
 	AuthorizationSettings *KeycloakResourceServer `json:"authorizationSettings,omitempty"`
+	// Authentication Flow Binding Overrides.
+	// +optional
+	AuthenticationFlowBindingOverrides map[string]string `json:"authenticationFlowBindingOverrides,omitempty"`
 }
 
 type KeycloakProtocolMapper struct {

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -313,6 +313,13 @@ func (in *KeycloakAPIClient) DeepCopyInto(out *KeycloakAPIClient) {
 		*out = new(KeycloakResourceServer)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.AuthenticationFlowBindingOverrides != nil {
+		in, out := &in.AuthenticationFlowBindingOverrides, &out.AuthenticationFlowBindingOverrides
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/keycloakclient/keycloakclient_controller.go
+++ b/pkg/controller/keycloakclient/keycloakclient_controller.go
@@ -175,6 +175,9 @@ func (r *ReconcileKeycloakClient) adjustCrDefaults(cr *kc.KeycloakClient) {
 	if cr.Spec.Client.Access == nil {
 		cr.Spec.Client.Access = make(map[string]bool)
 	}
+	if cr.Spec.Client.AuthenticationFlowBindingOverrides == nil {
+		cr.Spec.Client.AuthenticationFlowBindingOverrides = make(map[string]string)
+	}
 }
 
 func (r *ReconcileKeycloakClient) manageSuccess(client *kc.KeycloakClient, deleted bool) error {


### PR DESCRIPTION
## Additional Information
Currently you can create custom authentication flows on a realm CRD but you cannot use them in clients.