### PR TITLE
Updating user mailing list link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Kubernetes Operator based on the Operator SDK for creating and syncing resourc
 The official documentation might be found in the [here](https://www.keycloak.org/docs/latest/server_installation/index.html#_operator).
 
 * [Keycloak documentation](https://www.keycloak.org/documentation.html)
-* [User Mailing List](https://lists.jboss.org/mailman/listinfo/keycloak-user) - Mailing list for help and general questions about Keycloak
+* [User Mailing List](https://groups.google.com/g/keycloak-user) - Mailing list for help and general questions about Keycloak
 * [JIRA](https://issues.redhat.com/browse/KEYCLOAK-16220?jql=project%20%3D%20KEYCLOAK%20AND%20component%20%3D%20%22Container%20-%20Operator%22%20ORDER%20BY%20updated%20DESC) - Issue tracker for bugs and feature requests
 
 ## Reporting Security Vulnerabilities


### PR DESCRIPTION
As per https://lists.jboss.org/archives/list/keycloak-user@lists.jboss.org/thread/HXUE2IPVPB2HCD5TS3V6L7VEYQWI5JRZ/ , the user mailing list has moved to google groups in 2019

## JIRA ID
https://issues.redhat.com/browse/KEYCLOAK-19780

## Additional Information
This link should be updated to avoid confusion in those looking to ask questions about how to use the operator

## Verification Steps
Documentation change only

## Additional Notes 
I've removed the checklist as this is a minor non-code change. If this is the incorrect thing to do, please let me know