### PR TITLE
KEYCLOAK-19096 Add default labels to CSV Realm CR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Once the CRDs and RBAC rules are applied and the operator is running. Use the ex
 
 1.  clone this repo to `$GOPATH/src/github.com/keycloak/keycloak-operator`
 2.  run `make setup/mod cluster/prepare`
+2.  operator-sdk version [0.18.2] is mandatory. You can install it running `make setup/operator-sdk`    
 3.  run `make code/run`
 -- The above step will launch the operator on the local machine
 -- To see how do debug the operator or how to deploy to a cluster, see below alternatives to step 3

--- a/deploy/olm-catalog/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
@@ -35,7 +35,10 @@ metadata:
           "apiVersion": "keycloak.org/v1alpha1",
           "kind": "KeycloakRealm",
           "metadata": {
-            "name": "example-keycloakrealm"
+            "name": "example-keycloakrealm",
+            "labels": {
+              "app": "sso"
+            }
           },
           "spec": {
             "realm": {
@@ -358,4 +361,3 @@ spec:
   provider:
     name: Red Hat
   version: 15.0.1
-  replaces: keycloak-operator.v15.0.0

--- a/deploy/olm-catalog/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/keycloak-operator/15.0.1/manifests/keycloak-operator.v15.0.1.clusterserviceversion.yaml
@@ -361,3 +361,4 @@ spec:
   provider:
     name: Red Hat
   version: 15.0.1
+  replaces: keycloak-operator.v15.0.0


### PR DESCRIPTION
In order to test this PR :

1. create an Openshift 4.7 instance using the Katacoda [playground](https://www.katacoda.com/courses/openshift/playgrounds/openshift47)
1. create a catalog-source.yaml
```bash
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: test-catalog
  namespace: openshift-marketplace
  labels:
    application: keycloak
spec:
  sourceType: grpc
  image: quay.io/{your account}/keycloak-operator-test-catalog:{version}
   ```
3. remove the replace line (last one) in the CSV file to allow creating a catalog with only this version
3. create a test catalog bundle to install this test operator
```bash
docker build -f bundle.Dockerfile -t keycloak-operator-bundle:100 .

docker tag keycloak-operator-bundle:100 quay.io/{your account}/keycloak-operator-bundle:100

docker push quay.io/{your account}/keycloak-operator-bundle:100

~/{your path to operator-registry project}/operator-registry/bin/opm index add --bundles quay.io/{your account}/keycloak-operator-bundle:100 \
--tag quay.io/{your account}/keycloak-operator-test-catalog:100 --container-tool docker

docker push quay.io/{your account}/keycloak-operator-test-catalog:100

sed "s/{version}/100/g" catalog-source.yaml | kubectl apply -f -
```
4. install the operator from the OperatorHub screen in Openshift using the one on the test-catalog
1. create the keycloak, realm and client CRs with the default information
1. log to the keycloak admin and check that for the realm created there's the client created
