### PR TITLE
Modify github actions to build arm64 images also

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -24,13 +24,37 @@ jobs:
         with:
           string: ${{ github.repository }}
 
-      - name: Build and push container images
-        uses: docker/build-push-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
+          images: |
+            quay.io/${{ steps.repository.outputs.lowercase}}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Quay.io
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-          repository: ${{ steps.repository.outputs.lowercase }}
-          registry: quay.io
-          tag_with_ref: true
-          always_pull: true
+
+      - name: Build and push container images
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
+


### PR DESCRIPTION
## Additional Information
I want to use keycloak on an arm64 kubernetes cluster.

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

## Additional Notes 
Used [docker/build-push-action](https://github.com/docker/build-push-action)'s UPGRADE.md as the template for the change.