### PR TITLE
KEYCLOAK-19347 Keycloak Ingress doesn't work with Ingress Controller >= 1.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
     - name: Start minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.21.0'
-        kubernetes version: 'v1.21.2'
+        minikube version: 'v1.23.1'
+        kubernetes version: 'v1.22.1'
         driver: 'docker'
     - name: Configure Minikube
       run: |

--- a/pkg/model/keycloak_ingress.go
+++ b/pkg/model/keycloak_ingress.go
@@ -23,6 +23,7 @@ func KeycloakIngress(cr *kc.Keycloak) *networkingv1.Ingress {
 				"app": ApplicationName,
 			},
 			Annotations: map[string]string{
+				"kubernetes.io/ingress.class":                  "nginx",
 				"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 				"nginx.ingress.kubernetes.io/server-snippet": `
                       location ~* "^/auth/realms/master/metrics" {


### PR DESCRIPTION
* Added `kubernetes.io/ingress.class` annotation to make Ingress happy. Even though [some resources](https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#deprecating-the-ingress-class-annotation) state that the annotation is deprecated, it still seem well supported (is even included in [official examples](https://kubernetes.github.io/ingress-nginx/user-guide/basic-usage/)) and it is much simpler and more straightforward solution than introducing [`IngressClass` object](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class).
* Upgraded minikube in the CI to use newer Ingress where the issue is reproducible.