### PR TITLE
[KEYCLOAK-18294] Implement Service Account Roles

### DIFF
--- a/deploy/crds/keycloak.org_keycloakclients_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakclients_crd.yaml
@@ -804,6 +804,11 @@ spec:
                       type: object
                     type: array
                 type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
             required:
             - client
             - realmSelector

--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -22,6 +22,9 @@ type KeycloakClientSpec struct {
 	// Scope Mappings
 	// +optional
 	ScopeMappings *MappingsRepresentation `json:"scopeMappings,omitempty"`
+	// Service account realm roles for this client.
+	// +optional
+	ServiceAccountRealmRoles []string `json:"serviceAccountRealmRoles,omitempty"`
 }
 
 // https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_mappingsrepresentation

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -976,6 +976,11 @@ func (in *KeycloakClientSpec) DeepCopyInto(out *KeycloakClientSpec) {
 		*out = new(MappingsRepresentation)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ServiceAccountRealmRoles != nil {
+		in, out := &in.ServiceAccountRealmRoles, &out.ServiceAccountRealmRoles
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.openapi.go
@@ -358,6 +358,21 @@ func schema_pkg_apis_keycloak_v1alpha1_KeycloakClientSpec(ref common.ReferenceCa
 							Ref:         ref("./pkg/apis/keycloak/v1alpha1.MappingsRepresentation"),
 						},
 					},
+					"serviceAccountRealmRoles": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Service account realm roles for this client.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
 				},
 				Required: []string{"realmSelector", "client"},
 			},


### PR DESCRIPTION
## JIRA ID

KEYCLOAK-18294

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

## Verification Steps

1. Create a new `KeycloakClient` resource, add `.spec.client.serviceAccountRoles`.
2. Verify they get synced to the service account of the client.

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

## Additional Notes 

I had some issues building the operator in general. Updating the go.mod fixed the issue for me. The first two commits are about updating the build errors, and can later on be dropped if necessary.

The PR is an early draft and untested. Just as a starting point for a discussion.