### PR TITLE
KEYCLOAK-19503 escape name of the secret for client

### DIFF
--- a/pkg/common/client.go
+++ b/pkg/common/client.go
@@ -1064,7 +1064,7 @@ func validateKeycloakURL(url string, requester Requester) (string, error) {
 
 	res, err := requester.Do(req)
 	if err != nil {
-		log.Info(fmt.Sprintf("%s is not a valid keycloak url", url))
+		log.Info(fmt.Sprintf("%s is not a valid keycloak url : %s", url, err))
 		return "", nil
 	}
 	_ = res.Body.Close()

--- a/pkg/model/client_secret.go
+++ b/pkg/model/client_secret.go
@@ -1,16 +1,35 @@
 package model
 
 import (
+	"unicode"
+
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+func MakeK8sCompatibleName(text string) string {
+	// we only want letters and numbers
+	reg := []rune(SanitizeResourceName(text))
+
+	// we guarantee first and last char is an alpha and not a dot or a dash
+	if !unicode.IsLetter(reg[0]) && !unicode.IsNumber(reg[0]) {
+		reg = append([]rune{'a'}, reg...)
+	}
+	if !unicode.IsLetter(reg[len(reg)-1]) && !unicode.IsNumber(reg[len(reg)-1]) {
+		reg = append(reg, 'a')
+	}
+
+	return string(reg)
+}
+
 func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
+	escapedClientIDName := MakeK8sCompatibleName(cr.Spec.Client.ClientID)
 	return &v1.Secret{
 		ObjectMeta: v12.ObjectMeta{
-			Name:      ClientSecretName + "-" + cr.Spec.Client.ClientID,
+			Name:      ClientSecretName + "-" + escapedClientIDName,
 			Namespace: cr.Namespace,
 			Labels: map[string]string{
 				"app": ApplicationName,
@@ -24,8 +43,9 @@ func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
 }
 
 func ClientSecretSelector(cr *v1alpha1.KeycloakClient) client.ObjectKey {
+	escapedClientIDName := SanitizeResourceName(cr.Spec.Client.ClientID)
 	return client.ObjectKey{
-		Name:      ClientSecretName + "-" + cr.Spec.Client.ClientID,
+		Name:      ClientSecretName + "-" + escapedClientIDName,
 		Namespace: cr.Namespace,
 	}
 }

--- a/pkg/model/client_secret.go
+++ b/pkg/model/client_secret.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"unicode"
-
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	v1 "k8s.io/api/core/v1"
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -10,23 +8,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func MakeK8sCompatibleName(text string) string {
-	// we only want letters and numbers
-	reg := []rune(SanitizeResourceName(text))
-
-	// we guarantee first and last char is an alpha and not a dot or a dash
-	if !unicode.IsLetter(reg[0]) && !unicode.IsNumber(reg[0]) {
-		reg = append([]rune{'a'}, reg...)
-	}
-	if !unicode.IsLetter(reg[len(reg)-1]) && !unicode.IsNumber(reg[len(reg)-1]) {
-		reg = append(reg, 'a')
-	}
-
-	return string(reg)
-}
-
 func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
-	escapedClientIDName := MakeK8sCompatibleName(cr.Spec.Client.ClientID)
+	escapedClientIDName := SanitizeResourceNameWithAlphaNum(cr.Spec.Client.ClientID)
 	return &v1.Secret{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      ClientSecretName + "-" + escapedClientIDName,
@@ -43,7 +26,7 @@ func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
 }
 
 func ClientSecretSelector(cr *v1alpha1.KeycloakClient) client.ObjectKey {
-	escapedClientIDName := SanitizeResourceName(cr.Spec.Client.ClientID)
+	escapedClientIDName := SanitizeResourceNameWithAlphaNum(cr.Spec.Client.ClientID)
 	return client.ObjectKey{
 		Name:      ClientSecretName + "-" + escapedClientIDName,
 		Namespace: cr.Namespace,

--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -219,3 +219,18 @@ func FilterClientScopesByNames(clientScopes []v1alpha1.KeycloakClientScope, name
 
 	return filteredScopes
 }
+
+func SanitizeResourceNameWithAlphaNum(text string) string {
+	// we only want letters and numbers
+	reg := []rune(SanitizeResourceName(text))
+
+	// we guarantee first and last char is an alpha and not a dot or a dash
+	if !unicode.IsLetter(reg[0]) && !unicode.IsNumber(reg[0]) {
+		reg = append([]rune{'a'}, reg...)
+	}
+	if !unicode.IsLetter(reg[len(reg)-1]) && !unicode.IsNumber(reg[len(reg)-1]) {
+		reg = append(reg, 'a')
+	}
+
+	return string(reg)
+}


### PR DESCRIPTION
Signed-off-by: Jonathan Vila <jvilalop@redhat.com>

## JIRA ID
<!-- Add any additional information needed. Such as the Jira or GH issue this PR relates to or any other context you feel is necessary.) -->
https://issues.redhat.com/browse/KEYCLOAK-19503

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->
As the ticket says, when you use a clientId including a https url, it will fail as there are some chars not allowed for a K8s resource name

## Verification Steps
1. make cluster/prepare
2. Run operator from IDE , *from master branch*
2. deploy a keycloak.yaml
3. edit the keycloak CR and delete the annotation "service.alpha.openshift.io/serving-cert-secret-name"
4. delete the x509 secret
5. deploy a keycloakrealm.yaml
6. try to deploy a keycloakclient with clientid "https://whatever?value"  ---> will fail
7. stop the operator on the IDE, and now go to the PR branch, and run it
8. try to deploy a keycloakclient with clientid "https://whatever?value"  ---> will work


## Checklist:
- [X] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->