### PR TITLE
KEYCLOAK-17330 Update to latest stable keycloak-init container

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ All images used by the Operator might be controlled using dedicated Environmenta
  | `Keycloak`          | `RELATED_IMAGE_KEYCLOAK`                | `quay.io/keycloak/keycloak:9.0.2`                                |
  | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
- | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:master`                |
+ | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:latest`                |
  | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                    |
  | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
 

--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -18,7 +18,7 @@ const (
 	DefaultKeycloakImage         = "quay.io/keycloak/keycloak:latest"
 	DefaultRHSSOImageOpenJ9      = "registry.redhat.io/rh-sso-7/sso75-openj9-openshift-rhel8:7.5"
 	DefaultRHSSOImageOpenJDK     = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5"
-	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:master"
+	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:latest"
 	DefaultRHSSOInitContainer    = "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container:7.5"
 	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.16"
 	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"

--- a/set-version.sh
+++ b/set-version.sh
@@ -15,4 +15,4 @@ function replace_value_in_file() {
 replace_value_in_file ".*Version = " "$1" "version/version.go" "\""
 replace_value_in_file ".*DefaultKeycloakImage.*= " "quay.io\/keycloak\/keycloak:$1-legacy" "pkg/model/image_manager.go" "\""
 replace_value_in_file ".*image: " "quay.io\/keycloak\/keycloak-operator:$1" "deploy/operator.yaml"
-replace_value_in_file ".*DefaultKeycloakInitContainer.*= " "quay.io\/keycloak\/keycloak-init-container:$1" "pkg/model/image_manager.go" "\""
+replace_value_in_file ".*DefaultKeycloakInitContainer.*= " "quay.io\/keycloak\/keycloak-init-container:$1-legacy" "pkg/model/image_manager.go" "\""

--- a/set-version.sh
+++ b/set-version.sh
@@ -15,3 +15,4 @@ function replace_value_in_file() {
 replace_value_in_file ".*Version = " "$1" "version/version.go" "\""
 replace_value_in_file ".*DefaultKeycloakImage.*= " "quay.io\/keycloak\/keycloak:$1-legacy" "pkg/model/image_manager.go" "\""
 replace_value_in_file ".*image: " "quay.io\/keycloak\/keycloak-operator:$1" "deploy/operator.yaml"
+replace_value_in_file ".*DefaultKeycloakInitContainer.*= " "quay.io\/keycloak\/keycloak-init-container:$1" "pkg/model/image_manager.go" "\""


### PR DESCRIPTION
The keycloak-init-container image is currently pinned to the "master"
shared tag, which has not been updated for two years.

This commit updates the image tag to use the latest released tag for the
container.

This container comes with a couple of benefits:

* Accurate URL parsing, the Python parsing has issues.
* Ability to use basic auth URLs for extensions.
* Much smaller image size.

Fixes #478

## Additional Information

- Reduce the vulnerabilities from 309 ( 101 High ) to none (https://quay.io/repository/keycloak/keycloak-init-container?tag=latest&tab=tags)
- Allows the use of private extensions via the use of a basic auth URL.

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [x] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->