### PR TITLE
Use networking.k8s.io ingress in cluster role

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -63,7 +63,7 @@ rules:
       - update
       - watch
   - apiGroups:
-      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:


### PR DESCRIPTION
Fixes #461.

## Additional Information
- just deployed 15.0.2 and found that this was probably overlooked in https://github.com/keycloak/keycloak-operator/commit/fd5aeeb3a8dbf672d5751a021b9eea34006afaed#diff-dd2b7f73672812f28eaeefd88568f005bc349b4647e015a36b2789ad29b5221fL66

This fixes the apiGroups in the cluster role manifest.

Closes #461 