### PR TITLE
KEYCLOAK-395 adding IngressNginxSkipMetricsEnvironmentVariable

### DIFF
--- a/pkg/model/keycloak_ingress_test.go
+++ b/pkg/model/keycloak_ingress_test.go
@@ -3,6 +3,8 @@ package model
 import (
 	"testing"
 
+	"os"
+
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -131,4 +133,31 @@ func TestKeycloakIngress_testHostOverrideReconciled(t *testing.T) {
 
 	//then
 	assert.Equal(t, "host-override", reconciledIngress.Spec.Rules[0].Host)
+}
+
+func TestKeycloakIngress_testAnnotations(t *testing.T) {
+	snippet := `
+                      location ~* "^/auth/realms/master/metrics" {
+                          return 301 /auth/realms/master;
+                        }`
+
+	//given
+	os.Setenv(IngressNginxSkipMetricsEnvironmentVariable, "true")
+
+	//when
+	annotations := getIngressAnnotations()
+
+	//then
+	assert.Equal(t, "HTTPS", annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+	assert.Equal(t, "", annotations["nginx.ingress.kubernetes.io/server-snippet"])
+
+	//given
+	os.Unsetenv(IngressNginxSkipMetricsEnvironmentVariable)
+
+	//when
+	annotations = getIngressAnnotations()
+
+	//then
+	assert.Equal(t, "HTTPS", annotations["nginx.ingress.kubernetes.io/backend-protocol"])
+	assert.Equal(t, snippet, annotations["nginx.ingress.kubernetes.io/server-snippet"])
 }


### PR DESCRIPTION
## JIRA ID
395

## Additional Information
Not all nginx ingress admission controllers allow the provisioning of the "nginx.ingress.kubernetes.io/server-snippet" annotation; this is mainly related to CVE-2021-25742 discussed here: kubernetes/ingress-nginx#7837.
The PR introduces an environment variable in order to skip that annotation in such cases.
The annotation is used to install a redirect for the metrics endpoint, so it should not be critical for the operation of Keycloak.

## Checklist:
- [X] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [X] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

## Additional Notes 
Dev channel link: https://groups.google.com/g/keycloak-dev/c/ONHs1-wyDAw