### PR TITLE
KEYCLOAK-18547 Add tolerations and nodeSelector in Keycloak deployment

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -946,6 +946,12 @@ spec:
                             type: array
                         type: object
                     type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to constrain pods to run on particular
+                      set of Node(s)
+                    type: object
                   resources:
                     description: Resources (Requests and Limits) for the Pods.
                     properties:
@@ -972,6 +978,48 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  tolerations:
+                    description: Toleration for the Pods when using taints and toleration
+                      on nodes
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               migration:
                 description: Specify Migration configuration
@@ -1009,6 +1057,12 @@ spec:
               postgresDeploymentSpec:
                 description: Resources (Requests and Limits) for PostgresDeployment.
                 properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector to constrain pods to run on particular
+                      set of Node(s)
+                    type: object
                   resources:
                     description: Resources (Requests and Limits) for the Pods.
                     properties:
@@ -1035,6 +1089,48 @@ spec:
                           to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
+                  tolerations:
+                    description: Toleration for the Pods when using taints and toleration
+                      on nodes
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using
+                        the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match.
+                            Empty means match all taint effects. When specified, allowed
+                            values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to
+                            the value. Valid operators are Exists and Equal. Defaults
+                            to Equal. Exists is equivalent to wildcard for value,
+                            so that a pod can tolerate all taints of a particular
+                            category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of
+                            time the toleration (which must be of effect NoExecute,
+                            otherwise this field is ignored) tolerates the taint.
+                            By default, it is not set, which means tolerate the taint
+                            forever (do not evict). Zero and negative values will
+                            be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
                 type: object
               profile:
                 description: Profile used for controlling Operator behavior. Default

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -88,6 +88,12 @@ type DeploymentSpec struct {
 	// Resources (Requests and Limits) for the Pods.
 	// +optional
 	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Toleration for the Pods when using taints and toleration on nodes
+	// +optional
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// NodeSelector to constrain pods to run on particular set of Node(s)
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 type KeycloakDeploymentSpec struct {

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -99,6 +99,20 @@ func (in *ClientMappingsRepresentation) DeepCopy() *ClientMappingsRepresentation
 func (in *DeploymentSpec) DeepCopyInto(out *DeploymentSpec) {
 	*out = *in
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]v1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/model/keycloak_deployment.go
+++ b/pkg/model/keycloak_deployment.go
@@ -235,6 +235,8 @@ func KeycloakDeployment(cr *v1alpha1.Keycloak, dbSecret *v1.Secret) *v13.Statefu
 						},
 					},
 					ServiceAccountName: getServiceAccountName(cr),
+					Tolerations:        cr.Spec.KeycloakDeploymentSpec.Tolerations,
+					NodeSelector:       cr.Spec.KeycloakDeploymentSpec.NodeSelector,
 				},
 			},
 		},


### PR DESCRIPTION
## JIRA ID

https://issues.redhat.com/browse/KEYCLOAK-18547

## Additional Information

- As discussed in the [mailing list](https://groups.google.com/g/keycloak-dev/c/JYAV7BeAFHI), I didn't implemented the features on the PostgreSQL deployment

## Verification Steps

- A version of the operator has been deployed in production in a Kubernetes cluster with taints on the nodes, the deployment ran succesfully.

## Checklist:
- [X] Automated Tests
- [X] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [X] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->