### PR TITLE
Fix clusterrole wrong Ingress apiGroup

### DIFF
--- a/deploy/cluster_roles/cluster_role.yaml
+++ b/deploy/cluster_roles/cluster_role.yaml
@@ -63,7 +63,7 @@ rules:
       - update
       - watch
   - apiGroups:
-      - extensions
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:


### PR DESCRIPTION
When the clusterrole was created as a pendant to the normal role Ingress
resources were still found in the "extensions" apiGroup. This version of
the Ingress resource has long been deprecated. Now Ingresses are found
in networking.k8s.io/v1. The normal role has been updated since then but
the less used clusterRole seems to have been overlooked

Signed-off-by: Joel Pepper <pepper@bronze-deer.de>

## Related GH Issue
Closes <!-- Your issue ID -->

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

<!-- (Add this section if applicable)
## Verification Steps

Add the steps required to check this change. Following an example.

1. Go to `XX >> YY >> SS`
2. Create a new item `N` with the info `X`
3. Try to edit this item
4. Check if in the left menu the feature X is not so long present.
-->

## Checklist:
- [ ] Automated Tests
- [x] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [x] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->