### PR TITLE
Fix client secret naming scheme to match docs

### DIFF
--- a/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakclient_types.go
@@ -385,3 +385,7 @@ func init() {
 func (i *KeycloakClient) UpdateStatusSecondaryResources(kind string, resourceName string) {
 	i.Status.SecondaryResources = UpdateStatusSecondaryResources(i.Status.SecondaryResources, kind, resourceName)
 }
+
+func (i *KeycloakClient) DeleteFromStatusSecondaryResources(kind string, resourceName string) {
+	DeleteFromStatusSecondaryResources(i.Status.SecondaryResources, kind, resourceName)
+}

--- a/pkg/apis/keycloak/v1alpha1/util.go
+++ b/pkg/apis/keycloak/v1alpha1/util.go
@@ -18,3 +18,14 @@ func UpdateStatusSecondaryResources(secondaryResources map[string][]string, kind
 	// return new map
 	return secondaryResources
 }
+
+func DeleteFromStatusSecondaryResources(secondaryResources map[string][]string, kind string, resourceName string) {
+	resources := secondaryResources[kind]
+	for i, v := range resources {
+		if resourceName == v {
+			resources[i] = resources[len(resources)-1]
+			secondaryResources[kind] = resources[:len(resources)-1]
+			break
+		}
+	}
+}

--- a/pkg/apis/keycloak/v1alpha1/util_test.go
+++ b/pkg/apis/keycloak/v1alpha1/util_test.go
@@ -1,0 +1,30 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdateStatusSecondaryResources(t *testing.T) {
+	// given
+	var sd map[string][]string
+
+	// when
+	sd = UpdateStatusSecondaryResources(sd, "kind", "name-1")
+	sd = UpdateStatusSecondaryResources(sd, "kind", "name-2")
+
+	// then
+	assert.Equal(t, map[string][]string{"kind": {"name-1", "name-2"}}, sd)
+}
+
+func TestDeleteFromStatusSecondaryResources(t *testing.T) {
+	// given
+	sd := map[string][]string{"kind": {"name-1", "name-2"}}
+
+	// when
+	DeleteFromStatusSecondaryResources(sd, "kind", "name-1")
+
+	// then
+	assert.Equal(t, map[string][]string{"kind": {"name-2"}}, sd)
+}

--- a/pkg/common/client_state.go
+++ b/pkg/common/client_state.go
@@ -11,17 +11,18 @@ import (
 )
 
 type ClientState struct {
-	Client                *kc.KeycloakAPIClient
-	ClientSecret          *v1.Secret
-	Context               context.Context
-	Realm                 *kc.KeycloakRealm
-	Roles                 []kc.RoleRepresentation
-	DefaultRoleID         string
-	DefaultRoles          []kc.RoleRepresentation
-	ScopeMappings         *kc.MappingsRepresentation
-	AvailableClientScopes []kc.KeycloakClientScope
-	DefaultClientScopes   []kc.KeycloakClientScope
-	OptionalClientScopes  []kc.KeycloakClientScope
+	Client                 *kc.KeycloakAPIClient
+	ClientSecret           *v1.Secret // keycloak-client-secret-<custom resource name>
+	Context                context.Context
+	Realm                  *kc.KeycloakRealm
+	Roles                  []kc.RoleRepresentation
+	DefaultRoleID          string
+	DefaultRoles           []kc.RoleRepresentation
+	ScopeMappings          *kc.MappingsRepresentation
+	AvailableClientScopes  []kc.KeycloakClientScope
+	DefaultClientScopes    []kc.KeycloakClientScope
+	OptionalClientScopes   []kc.KeycloakClientScope
+	DeprecatedClientSecret *v1.Secret // keycloak-client-secret-<clientID>
 }
 
 func NewClientState(context context.Context, realm *kc.KeycloakRealm) *ClientState {
@@ -58,6 +59,14 @@ func (i *ClientState) Read(context context.Context, cr *kc.KeycloakClient, realm
 	err = i.readClientSecret(context, cr, i.Client, controllerClient)
 	if err != nil {
 		return err
+	}
+
+	if cr.Name != cr.Spec.Client.ClientID {
+		// only read when these fields aren't equal to avoid unwanted cyclical create / delete of client secret
+		err = i.readDepcreatedClientSecret(context, cr, i.Client, controllerClient)
+		if err != nil {
+			return err
+		}
 	}
 
 	if i.Client != nil {
@@ -132,4 +141,25 @@ func (i *ClientState) readDefaultRoles(cr *kc.KeycloakClient, realmClient Keyclo
 	i.DefaultRoleID = realm.Spec.Realm.DefaultRole.ID
 	i.DefaultRoles, err = realmClient.ListRealmRoleClientRoleComposites(i.Realm.Spec.Realm.Realm, i.DefaultRoleID, cr.Spec.Client.ID)
 	return err
+}
+
+// Read client secret created using the previous naming scheme, i.e., keycloak-client-secret-<CLIENT_ID>.
+// See GH issue #473 and KEYCLOAK-18346.
+func (i *ClientState) readDepcreatedClientSecret(context context.Context, cr *kc.KeycloakClient, clientSpec *kc.KeycloakAPIClient, controllerClient client.Client) error {
+	key := model.DeprecatedClientSecretSelector(cr)
+	secret := model.DeprecatedClientSecret(cr)
+
+	err := controllerClient.Get(context, key, secret)
+	if err != nil {
+		if !apiErrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		i.DeprecatedClientSecret = secret.DeepCopy()
+	}
+
+	// delete reference to keycloak-client-secret-<CLIENT_ID> in secondary resources
+	cr.DeleteFromStatusSecondaryResources(secret.Kind, secret.Name)
+
+	return nil
 }

--- a/pkg/common/cluster_actions.go
+++ b/pkg/common/cluster_actions.go
@@ -24,6 +24,7 @@ type ActionRunner interface {
 	RunAll(desiredState DesiredClusterState) error
 	Create(obj runtime.Object) error
 	Update(obj runtime.Object) error
+	Delete(obj runtime.Object) error
 	CreateRealm(obj *v1alpha1.KeycloakRealm) error
 	DeleteRealm(obj *v1alpha1.KeycloakRealm) error
 	CreateClient(keycloakClient *v1alpha1.KeycloakClient, Realm string) error
@@ -120,6 +121,10 @@ func (i *ClusterActionRunner) Update(obj runtime.Object) error {
 	}
 
 	return i.client.Update(i.context, obj)
+}
+
+func (i *ClusterActionRunner) Delete(obj runtime.Object) error {
+	return i.client.Delete(i.context, obj)
 }
 
 // Create a new realm using the keycloak api
@@ -410,6 +415,13 @@ type GenericUpdateAction struct {
 	Msg string
 }
 
+// An action to delete generic kubernetes resources
+// (resources that don't require special treatment)
+type GenericDeleteAction struct {
+	Ref runtime.Object
+	Msg string
+}
+
 type CreateRealmAction struct {
 	Ref *v1alpha1.KeycloakRealm
 	Msg string
@@ -595,6 +607,10 @@ func (i GenericCreateAction) Run(runner ActionRunner) (string, error) {
 
 func (i GenericUpdateAction) Run(runner ActionRunner) (string, error) {
 	return i.Msg, runner.Update(i.Ref)
+}
+
+func (i GenericDeleteAction) Run(runner ActionRunner) (string, error) {
+	return i.Msg, runner.Delete(i.Ref)
 }
 
 func (i CreateRealmAction) Run(runner ActionRunner) (string, error) {

--- a/pkg/controller/keycloakclient/keycloakclient_reconciler.go
+++ b/pkg/controller/keycloakclient/keycloakclient_reconciler.go
@@ -47,6 +47,12 @@ func (i *KeycloakClientReconciler) Reconcile(state *common.ClientState, cr *kc.K
 		desired.AddAction(i.getUpdatedClientSecretState(state, cr))
 	}
 
+	if state.DeprecatedClientSecret != nil {
+		// Delete client secret created using the previous naming scheme, i.e., keycloak-client-secret-<CLIENT_ID>.
+		// See GH issue #473 and KEYCLOAK-18346.
+		desired.AddAction(i.getDeletedDeprecatedClientSecretState(state, cr))
+	}
+
 	i.ReconcileRoles(state, cr, &desired)
 
 	i.ReconcileScopeMappings(state, cr, &desired)
@@ -292,10 +298,17 @@ func (i *KeycloakClientReconciler) getCreatedClientState(state *common.ClientSta
 	}
 }
 
+func (i *KeycloakClientReconciler) getDeletedDeprecatedClientSecretState(state *common.ClientState, cr *kc.KeycloakClient) common.ClusterAction {
+	return common.GenericDeleteAction{
+		Ref: state.DeprecatedClientSecret,
+		Msg: fmt.Sprintf("delete deprecated client secret %v/%v", cr.Namespace, cr.Spec.Client.ClientID),
+	}
+}
+
 func (i *KeycloakClientReconciler) getUpdatedClientSecretState(state *common.ClientState, cr *kc.KeycloakClient) common.ClusterAction {
 	return common.GenericUpdateAction{
 		Ref: model.ClientSecretReconciled(cr, state.ClientSecret),
-		Msg: fmt.Sprintf("update client secret %v/%v", cr.Namespace, cr.Spec.Client.ClientID),
+		Msg: fmt.Sprintf("update client secret %v/%v", cr.Namespace, cr.Name),
 	}
 }
 
@@ -310,7 +323,7 @@ func (i *KeycloakClientReconciler) getUpdatedClientState(state *common.ClientSta
 func (i *KeycloakClientReconciler) getCreatedClientSecretState(state *common.ClientState, cr *kc.KeycloakClient) common.ClusterAction {
 	return common.GenericCreateAction{
 		Ref: model.ClientSecret(cr),
-		Msg: fmt.Sprintf("create client secret %v/%v", cr.Namespace, cr.Spec.Client.ClientID),
+		Msg: fmt.Sprintf("create client secret %v/%v", cr.Namespace, cr.Name),
 	}
 }
 

--- a/pkg/model/client_secret.go
+++ b/pkg/model/client_secret.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
-	escapedSecretName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Spec.Client.ClientID)
+	escapedSecretName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Name)
 	return &v1.Secret{
 		ObjectMeta: v12.ObjectMeta{
 			Name:      escapedSecretName,
@@ -26,7 +26,7 @@ func ClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
 }
 
 func ClientSecretSelector(cr *v1alpha1.KeycloakClient) client.ObjectKey {
-	escapedSelectorName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Spec.Client.ClientID)
+	escapedSelectorName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Name)
 	return client.ObjectKey{
 		Name:      escapedSelectorName,
 		Namespace: cr.Namespace,
@@ -41,4 +41,29 @@ func ClientSecretReconciled(cr *v1alpha1.KeycloakClient, currentState *v1.Secret
 		ClientSecretClientSecretProperty: []byte(cr.Spec.Client.Secret),
 	}
 	return reconciled
+}
+
+func DeprecatedClientSecret(cr *v1alpha1.KeycloakClient) *v1.Secret {
+	escapedSecretName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Spec.Client.ClientID)
+	return &v1.Secret{
+		ObjectMeta: v12.ObjectMeta{
+			Name:      escapedSecretName,
+			Namespace: cr.Namespace,
+			Labels: map[string]string{
+				"app": ApplicationName,
+			},
+		},
+		Data: map[string][]byte{
+			ClientSecretClientIDProperty:     []byte(cr.Spec.Client.ClientID),
+			ClientSecretClientSecretProperty: []byte(cr.Spec.Client.Secret),
+		},
+	}
+}
+
+func DeprecatedClientSecretSelector(cr *v1alpha1.KeycloakClient) client.ObjectKey {
+	escapedSelectorName := SanitizeResourceNameWithAlphaNum(ClientSecretName + "-" + cr.Spec.Client.ClientID)
+	return client.ObjectKey{
+		Name:      escapedSelectorName,
+		Namespace: cr.Namespace,
+	}
 }


### PR DESCRIPTION
## Related GH Issue
Closes #473

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

- Updated the naming scheme of the kubernetes secrets created by `KeylcoakClient` custom resources to now use the custom resource name (which matches Keycloak documentation) over the previously used `clientID`.
- `KeycloakClient` reconciliation process will create secrets using custom resource name, i.e.`keycloak-client-secret-<custom resource name>`, and also check for existence of secret using the old naming scheme, i.e. `keycloak-client-secret-<clientID>`, and delete appropriately. Put condition in place to avoid cyclical creation/deletion of secrets in case of `client_id == custom_resource_name`.
- Open to suggestions on approach and names used (deprecated was one that came to mind 🤷 )
- Tip of the hat to @imykolenko for their initial work in #361 👍 

## Verification Steps

See examples to reproduce issue caused by the `clientID` based naming scheme of the k8s secrets in [KEYCLOAK-18346](https://issues.redhat.com/browse/KEYCLOAK-18346).

## Checklist:
- [x] Automated Tests
- [x] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [x] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->