### PR TITLE
Init container missing tag: latest to legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ All images used by the Operator might be controlled using dedicated Environmenta
  | `Keycloak`          | `RELATED_IMAGE_KEYCLOAK`                | `quay.io/keycloak/keycloak:9.0.2`                                |
  | `RHSSO` for OpenJ9  | `RELATED_IMAGE_RHSSO_OPENJ9`            | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
  | `RHSSO` for OpenJDK | `RELATED_IMAGE_RHSSO_OPENJDK`           | `registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-1`        |
- | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:latest`                |
+ | Init container      | `RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER` | `quay.io/keycloak/keycloak-init-container:legacy`                |
  | Backup container    | `RELATED_IMAGE_RHMI_BACKUP_CONTAINER`   | `quay.io/integreatly/backup-container:1.0.16`                    |
  | Postgresql          | `RELATED_IMAGE_POSTGRESQL`              | `registry.redhat.io/rhel8/postgresql-10:1`                       |
 

--- a/pkg/model/image_manager.go
+++ b/pkg/model/image_manager.go
@@ -18,7 +18,7 @@ const (
 	DefaultKeycloakImage         = "quay.io/keycloak/keycloak:latest"
 	DefaultRHSSOImageOpenJ9      = "registry.redhat.io/rh-sso-7/sso75-openj9-openshift-rhel8:7.5"
 	DefaultRHSSOImageOpenJDK     = "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5"
-	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:latest"
+	DefaultKeycloakInitContainer = "quay.io/keycloak/keycloak-init-container:legacy"
 	DefaultRHSSOInitContainer    = "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container:7.5"
 	DefaultRHMIBackupContainer   = "quay.io/integreatly/backup-container:1.0.16"
 	DefaultPostgresqlImage       = "registry.access.redhat.com/rhscl/postgresql-10-rhel7:1"


### PR DESCRIPTION
## Related GH Issue
Related to https://github.com/keycloak/keycloak-operator/pull/389

## Additional Information
```
docker pull quay.io/keycloak/keycloak-init-container:latest
Error response from daemon: unknown: Tag latest was deleted or has expired. To pull, revive via time machine
```

Since I can't see tag `latest` but `legacy` is the most recent, assuming `legacy` was intended as the new default.