### PR TITLE
#512 Fix Keycloak StatefulSet selector not being set properly

### DIFF
--- a/pkg/model/util.go
+++ b/pkg/model/util.go
@@ -236,15 +236,17 @@ func SanitizeResourceNameWithAlphaNum(text string) string {
 }
 
 func AddPodLabels(cr *v1alpha1.Keycloak, labels map[string]string) map[string]string {
+	mergedPodLabels := map[string]string{}
+
 	// We add the Pod Labels defined in the constants
 	for key, value := range PodLabels {
-		labels[key] = value
+		mergedPodLabels[key] = value
 	}
 
 	// We add the PodLabel labels coming from CR Env Vars
 	for key, value := range cr.Spec.KeycloakDeploymentSpec.PodLabels {
-		labels[key] = value
+		mergedPodLabels[key] = value
 	}
 
-	return labels
+	return mergedPodLabels
 }

--- a/pkg/model/util_test.go
+++ b/pkg/model/util_test.go
@@ -177,6 +177,7 @@ func TestPodLabels_When_EnvVars_Then_FullListOfLabels(t *testing.T) {
 	}
 	totalLabels := AddPodLabels(&cr, labels)
 	assert.Equal(t, 6, len(totalLabels))
+	assert.Equal(t, 2, len(labels))
 	assert.Contains(t, totalLabels, "LabelToTest")
 	assert.Contains(t, totalLabels, "SecondLabelToTest")
 	assert.Contains(t, totalLabels, "FirstLabel")


### PR DESCRIPTION
## Related GH Issue
Closes [#512](https://github.com/keycloak/keycloak-operator/issues/512)

## Additional Information
This is a major bug because this leaves everything in an incorrect cluster state

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)
