### PR TITLE
Update operator image coordinates in set-version.sh

### DIFF
--- a/set-version.sh
+++ b/set-version.sh
@@ -14,5 +14,5 @@ function replace_value_in_file() {
 
 replace_value_in_file ".*Version = " "$1" "version/version.go" "\""
 replace_value_in_file ".*DefaultKeycloakImage.*= " "quay.io\/keycloak\/keycloak:$1-legacy" "pkg/model/image_manager.go" "\""
-replace_value_in_file ".*image: " "quay.io\/keycloak\/keycloak-operator:$1" "deploy/operator.yaml"
+replace_value_in_file ".*image: " "quay.io\/keycloak\/keycloak-operator:$1-legacy" "deploy/operator.yaml"
 replace_value_in_file ".*DefaultKeycloakInitContainer.*= " "quay.io\/keycloak\/keycloak-init-container:$1-legacy" "pkg/model/image_manager.go" "\""


### PR DESCRIPTION
Similar to #465 the keycloak-operator image also needs '-legacy' appended, otherwise it will fail to pull the non-existent 17.0.1

https://quay.io/repository/keycloak/keycloak-operator?tab=tags

## Related GH Issue
Closes #515

## Checklist:
- [ ] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)