### PR TITLE
Add defaultDefaultClientScopes field to KeycloakRealm resource

### DIFF
--- a/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloakrealms_crd.yaml
@@ -831,6 +831,11 @@ spec:
                       - clientId
                       type: object
                     type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
                   defaultLocale:
                     description: Default Locale
                     type: string

--- a/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloakrealm_types.go
@@ -73,6 +73,10 @@ type KeycloakAPIRealm struct {
 	// +optional
 	ClientScopes []KeycloakClientScope `json:"clientScopes,omitempty"`
 
+	// Default client scopes to add to all new clients
+	// +optional
+	DefaultDefaultClientScopes []string `json:"defaultDefaultClientScopes,omitempty"`
+
 	// Authentication flows
 	// +optional
 	AuthenticationFlows []KeycloakAPIAuthenticationFlow `json:"authenticationFlows,omitempty"`

--- a/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/keycloak/v1alpha1/zz_generated.deepcopy.go
@@ -417,6 +417,11 @@ func (in *KeycloakAPIRealm) DeepCopyInto(out *KeycloakAPIRealm) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.DefaultDefaultClientScopes != nil {
+		in, out := &in.DefaultDefaultClientScopes, &out.DefaultDefaultClientScopes
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.AuthenticationFlows != nil {
 		in, out := &in.AuthenticationFlows, &out.AuthenticationFlows
 		*out = make([]KeycloakAPIAuthenticationFlow, len(*in))

--- a/test/e2e/keycloak_realm_test.go
+++ b/test/e2e/keycloak_realm_test.go
@@ -260,6 +260,7 @@ func keycloakRealmWithClientScopesTest(t *testing.T, framework *test.Framework, 
 			},
 		},
 	}
+	keycloakRealmCR.Spec.Realm.DefaultDefaultClientScopes = []string{"profile"}
 
 	err := Create(framework, keycloakRealmCR, ctx)
 	if err != nil {


### PR DESCRIPTION
## Related GH Issue
Closes https://github.com/keycloak/keycloak-operator/issues/534

## Additional Information
<!-- What/Why/How or any other context you feel is necessary.) -->

## Verification Steps
1. Run the operator
2. Create a KeycloakRealm resource with a client scope and add that scope to the defaultDefaultClientScopes field on the resource
3. Check that the client scope is listed in the default client scopes list in Keycloak and that, when adding a new client, the scope gets added to its default scopes list.

## Checklist:
- [x] Automated Tests
- [ ] [Documentation](https://github.com/keycloak/keycloak-documentation) changes if necessary
- [ ] (If required) Discussed on [Keycloak DEV](https://groups.google.com/forum/#!forum/keycloak-dev)

<!-- (Add this section if applicable)
## Additional Notes 
-->