### PR TITLE
Context root for external Keycloak instances

### DIFF
--- a/deploy/crds/keycloak.org_keycloaks_crd.yaml
+++ b/deploy/crds/keycloak.org_keycloaks_crd.yaml
@@ -54,6 +54,10 @@ spec:
                 description: Contains configuration for external Keycloak instances.
                   Unmanaged needs to be set to true to use this.
                 properties:
+                  contextRoot:
+                    description: Context root for Keycloak. If not set, the default
+                      "/auth/" is used. Must end with "/".
+                    type: string
                   enabled:
                     description: If set to true, this Keycloak will be treated as
                       an external instance. The unmanaged field also needs to be set

--- a/pkg/apis/keycloak/v1alpha1/keycloak_types.go
+++ b/pkg/apis/keycloak/v1alpha1/keycloak_types.go
@@ -178,6 +178,9 @@ type KeycloakExternal struct {
 	// The URL to use for the keycloak admin API. Needs to be set if external is true.
 	// +optional
 	URL string `json:"url,omitempty"`
+	// Context root for Keycloak. If not set, the default "/auth/" is used.
+	// Must end with "/".
+	ContextRoot string `json:"contextRoot,omitempty"`
 }
 
 type KeycloakExternalAccess struct {

--- a/pkg/common/client_test.go
+++ b/pkg/common/client_test.go
@@ -349,3 +349,18 @@ func TestClient_useKeycloakServerCertificate(t *testing.T) {
 	defer resp.Body.Close()
 	assert.Equal(t, resp.StatusCode, 200)
 }
+
+func TestClient_GetFullKeycloakPath(t *testing.T) {
+	serverURL := "https://foo.bar:8080"
+	customContext := "/"
+
+	client := Client{
+		URL:         serverURL,
+		contextRoot: customContext,
+	}
+	assert.Equal(t, serverURL+customContext, client.GetFullKeycloakPath())
+
+	client.contextRoot = ""
+
+	assert.Equal(t, serverURL+"/auth/", client.GetFullKeycloakPath())
+}


### PR DESCRIPTION
Closes #572

The solution might seem a bit cumbersome but I didn't want to change the behaviour of `Client.URL` (e.g. we could integrate to context root directly to there). In case somebody uses it that'd be a breaking change. Hence introducing a new field `Client.contextRoot`.